### PR TITLE
Add unit test to demonstrate SPeL/JsonPath expressions that can be useful for handling OpenId introspection data.

### DIFF
--- a/src/test/java/io/gravitee/el/spel/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/SpelTemplateEngineTest.java
@@ -216,4 +216,31 @@ public class SpelTemplateEngineTest {
 
     }
 
+    @Test
+    public void shouldJsonPathFunctionGroupsForBoolean() {
+
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("profile", "{ \"lastname\": \"DOE\", \"firstname\": \"JOHN\", \"age\": 35"
+                + ", \"groups\" : [\"Group1\", \"Group2\", \"Group3\"]"
+                + ", \"emptiness\" : []"
+                + ", \"nothingness\" : null"
+                + " }");
+
+        String content = "{#jsonPath(#profile, '$.groups').contains('Group2')}";
+        boolean result = engine.getValue(content , boolean.class);
+        Assert.assertTrue(result);
+
+        content = "{#jsonPath(#profile, '$.groups').contains('Group4')}";
+        result = engine.getValue(content , boolean.class);
+        Assert.assertFalse(result);
+
+        content = "{#jsonPath(#profile, '$.emptiness').contains('Group4')}";
+        result = engine.getValue(content , boolean.class);
+        Assert.assertFalse(result);
+
+        content = "{#jsonPath(#profile, '$.nothingness')?.contains('Group4')?:false}";
+        result = engine.getValue(content , boolean.class);
+        Assert.assertFalse(result);
+    }
+    
 }


### PR DESCRIPTION
Just adding a single test case to show how JsonPath expressions that return arrays can be used in a SPeL expression.