### PR TITLE
feat: allow access to SSL attributes in EL TemplateEngine

### DIFF
--- a/src/main/resources/whitelist
+++ b/src/main/resources/whitelist
@@ -22,6 +22,8 @@ class java.text.MessageFormat
 
 class java.util.Calendar
 
+class io.gravitee.gateway.api.el.EvaluableSSLPrincipal
+
 # Allows by method signatures
 method java.lang.Object equals java.lang.Object
 method java.lang.Object hashCode


### PR DESCRIPTION
Authorize `EvaluableSSLPrincipal` class to be evaluated in TemplateEngine

gravitee-io/issues#5322