### PR TITLE
feat: improve map access with dot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <properties>
         <json-path.version>2.6.0</json-path.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.31.1-SNAPSHOT</gravitee-gateway-api.version>
         <jmh.version>1.21</jmh.version>
     </properties>
 </project>

--- a/src/main/java/io/gravitee/el/spel/context/ReadOnlyMapAccessor.java
+++ b/src/main/java/io/gravitee/el/spel/context/ReadOnlyMapAccessor.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.context;
+
+import org.springframework.context.expression.MapAccessor;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.EvaluationContext;
+
+/**
+ * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ReadOnlyMapAccessor extends MapAccessor {
+
+    @Override
+    public boolean canWrite(EvaluationContext context, Object target, String name) throws AccessException {
+        return false;
+    }
+}

--- a/src/main/java/io/gravitee/el/spel/context/SecuredEvaluationContext.java
+++ b/src/main/java/io/gravitee/el/spel/context/SecuredEvaluationContext.java
@@ -31,7 +31,8 @@ public class SecuredEvaluationContext implements EvaluationContext {
     // Read only property access.
     private static final List<PropertyAccessor> propertyAccessors = Arrays.asList(
         DataBindingPropertyAccessor.forReadOnlyAccess(),
-        new HttpHeadersPropertyAccessor()
+        new HttpHeadersPropertyAccessor(),
+        new ReadOnlyMapAccessor()
     );
 
     // Secure method resolver to allow only whitelisted methods.


### PR DESCRIPTION
**Issue**

It would be simpler to access to map value with dot syntax like `{#context.attributes.api}`

https://github.com/gravitee-io/issues/issues/7228
