### PR TITLE
template evaluation on missing headers

### DIFF
--- a/src/main/java/io/gravitee/el/spel/context/HttpHeadersPropertyAccessor.java
+++ b/src/main/java/io/gravitee/el/spel/context/HttpHeadersPropertyAccessor.java
@@ -46,7 +46,7 @@ public class HttpHeadersPropertyAccessor implements PropertyAccessor {
 
         List<String> values = headers.getAll(name);
 
-        if (values == null) {
+        if (values == null || values.isEmpty()) {
             return TypedValue.NULL;
         }
 

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
@@ -18,6 +18,8 @@ package io.gravitee.el.spel.context;
 import static io.gravitee.el.spel.context.SecuredMethodResolver.EL_WHITELIST_LIST_KEY;
 import static io.gravitee.el.spel.context.SecuredMethodResolver.EL_WHITELIST_MODE_KEY;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -99,6 +101,19 @@ public class SpelTemplateEngineTest {
 
         String value = engine.convert("custom-{#request.headers['X-Gravitee-Endpoint']}");
         assertEquals("custom-my_api_host", value);
+    }
+
+    @Test
+    public void shouldTransformWithRequestHeader_emptyHeaderList() {
+        HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(headers.getAll(any())).thenReturn(Collections.emptyList());
+        when(request.headers()).thenReturn(headers);
+
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("request", new EvaluableRequest(request));
+
+        assertTrue(engine.getValue("{#request.headers['X-Gravitee-Endpoint'] == null}", Boolean.class));
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7283

**Description**
Until 3.15.0, the implementation of `headers.getAll` returned null if a header is not sent in the request.
Since 3.15.0, it returns an empty list. But it's a breaking change for every users that test headers in their expression language condition.

This PR fix the regression.
