### PR TITLE
fix(spel): catch parsing exception and return Maybe on error

### DIFF
--- a/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
+++ b/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
@@ -46,8 +46,14 @@ public class SpelTemplateEngine implements TemplateEngine {
 
     @Override
     public <T> Maybe<T> eval(String expression, Class<T> clazz) {
-        final CachedExpression exp = spelExpressionParser.parseAndCacheExpression(expression);
-        return templateContext.evaluationContext(exp).flatMapMaybe(evaluationContext -> eval(exp, evaluationContext, clazz));
+        try {
+            CachedExpression cachedExpression = spelExpressionParser.parseAndCacheExpression(expression);
+            return templateContext
+                .evaluationContext(cachedExpression)
+                .flatMapMaybe(evaluationContext -> eval(cachedExpression, evaluationContext, clazz));
+        } catch (Exception e) {
+            return Maybe.error(e);
+        }
     }
 
     @Override

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
+import org.springframework.expression.ParseException;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -615,5 +616,12 @@ public class SpelTemplateEngineTest {
 
         ReflectionTestUtils.setField(SecuredMethodResolver.class, "securedResolver", SecuredResolver.getInstance());
         ReflectionTestUtils.setField(SecuredContructorResolver.class, "securedResolver", SecuredResolver.getInstance());
+    }
+
+    @Test
+    public void shouldThrowParsingExceptionWithWrongExpression() {
+        String wrongExpression = "{#";
+        final TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval(wrongExpression, Boolean.class).test().assertFailure(ParseException.class);
     }
 }


### PR DESCRIPTION
**Issue**
When testing jupiter debug mode, it appears that if the condition evaluated is malformated an exception is thrown out of reactive contexte.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.10.1-jupiter-fix-el-expression-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/1.10.1-jupiter-fix-el-expression-SNAPSHOT/gravitee-expression-language-1.10.1-jupiter-fix-el-expression-SNAPSHOT.zip)
  <!-- Version placeholder end -->
