### PR TITLE
fix: restore HTTP headers backward compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <json-path.version>2.6.0</json-path.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
-        <gravitee-gateway-api.version>1.31.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.32.3</gravitee-gateway-api.version>
         <jmh.version>1.21</jmh.version>
     </properties>
 
@@ -106,6 +106,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/el/spel/context/HttpHeadersPropertyAccessor.java
+++ b/src/main/java/io/gravitee/el/spel/context/HttpHeadersPropertyAccessor.java
@@ -28,7 +28,7 @@ import org.springframework.expression.TypedValue;
  */
 public class HttpHeadersPropertyAccessor implements PropertyAccessor {
 
-    private final Class<?>[] TARGET_CLASSES = new Class[] { HttpHeaders.class };
+    private static final Class<?>[] TARGET_CLASSES = new Class[] { HttpHeaders.class };
 
     @Override
     public Class<?>[] getSpecificTargetClasses() {
@@ -37,7 +37,7 @@ public class HttpHeadersPropertyAccessor implements PropertyAccessor {
 
     @Override
     public boolean canRead(EvaluationContext context, Object target, String name) throws AccessException {
-        return true;
+        return target instanceof HttpHeaders;
     }
 
     @Override

--- a/src/main/resources/whitelist
+++ b/src/main/resources/whitelist
@@ -23,6 +23,7 @@ class java.text.MessageFormat
 class java.util.Calendar
 
 class io.gravitee.gateway.api.el.EvaluableSSLPrincipal
+class io.gravitee.gateway.api.http.HttpHeaders
 
 # Allows by method signatures
 method java.lang.Object equals java.lang.Object
@@ -73,5 +74,7 @@ method java.util.Random nextInt int
 method java.util.Random nextLong
 method java.util.TimeZone getTimeZone java.lang.String
 method java.util.UUID randomUUID
+method io.gravitee.common.util.MultiValueMap toSingleValueMap
+method io.gravitee.common.util.MultiValueMap getFirst java.lang.Object
 
 # Allows by constructor signatures

--- a/src/test/java/io/gravitee/el/spel/context/HttpHeadersPropertyAccessorTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/HttpHeadersPropertyAccessorTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.TypedValue;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpHeadersPropertyAccessorTest {
+
+    private HttpHeadersPropertyAccessor cut;
+
+    @Before
+    public void setUp() {
+        cut = new HttpHeadersPropertyAccessor();
+    }
+
+    @Test
+    public void canRead() throws AccessException {
+        assertThat(cut.canRead(mock(EvaluationContext.class), HttpHeaders.create(), "property")).isTrue();
+    }
+
+    @Test
+    public void canNotRead() throws AccessException {
+        assertThat(cut.canRead(mock(EvaluationContext.class), HttpHeaderNames.ACCEPT, "property")).isFalse();
+    }
+
+    @Test
+    public void shouldRead() throws AccessException {
+        final HttpHeaders headers = HttpHeaders.create();
+        headers.add("Header", "value1").add("Header", "value2");
+
+        final TypedValue result = cut.read(mock(EvaluationContext.class), headers, "header");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTypeDescriptor()).isNotNull();
+        assertThat(result.getTypeDescriptor().isAssignableTo(TypeDescriptor.valueOf(Collection.class))).isTrue();
+        assertThat((Collection<String>) result.getValue()).hasSize(2).contains("value1", "value2");
+    }
+
+    @Test
+    public void shouldReadNullValue() throws AccessException {
+        final TypedValue result = cut.read(mock(EvaluationContext.class), HttpHeaders.create(), "header");
+
+        assertThat(result).isNotNull().isEqualTo(TypedValue.NULL);
+    }
+
+    @Test
+    public void shouldReadEmptyValue() throws AccessException {
+        final HttpHeaders headers = HttpHeaders.create();
+        headers.add("header", Collections.emptyList());
+
+        final TypedValue result = cut.read(mock(EvaluationContext.class), headers, "header");
+
+        assertThat(result).isNotNull().isEqualTo(TypedValue.NULL);
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7812

**Description**

- Improve `canRead` method doing some type checking
- Enrich whitelist to take benefit from `MultiValueMap` and `io.gravitee.gateway.api.http.HttpHeaders`

⚠️ Waiting for https://github.com/gravitee-io/gravitee-gateway-api/pull/118 to be merged 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.3-issues-7812-retro-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/1.9.3-issues-7812-retro-headers-SNAPSHOT/gravitee-expression-language-1.9.3-issues-7812-retro-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
