### PR TITLE
fix: resolve regex with quantifiers

### DIFF
--- a/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
+++ b/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
@@ -33,7 +33,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  */
 public class SpelTemplateEngine implements TemplateEngine {
 
-    private static final String EXPRESSION_REGEX = "\\{( *[^#T\\( ])";
+    private static final String EXPRESSION_REGEX = "\\{( *[^#T\\( 0-9])";
     private static final Pattern EXPRESSION_REGEX_PATTERN = Pattern.compile(EXPRESSION_REGEX);
     private static final String EXPRESSION_REGEX_SUBSTITUTE = "{'{'}$1";
     private static final ParserContext PARSER_CONTEXT = new TemplateParserContext();

--- a/src/test/java/io/gravitee/el/spel/EvaluableRequest.java
+++ b/src/test/java/io/gravitee/el/spel/EvaluableRequest.java
@@ -49,4 +49,8 @@ public class EvaluableRequest {
     public String getContent() {
         return null;
     }
+
+    public String getPathInfo() {
+        return request.pathInfo();
+    }
 }


### PR DESCRIPTION
gravitee-io/issues#8217
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.5-2359-fix-regex-quantifiers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/1.9.5-2359-fix-regex-quantifiers-SNAPSHOT/gravitee-expression-language-1.9.5-2359-fix-regex-quantifiers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
