### PR TITLE
feat: use higher level HttpExecutionContext for TemplateProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>2.5</gravitee-bom.version>
         <json-path.version>2.6.0</json-path.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
-        <gravitee-gateway-api.version>1.34.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.40.0</gravitee-gateway-api.version>
         <jmh.version>1.35</jmh.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
         <gravitee-node.version>1.24.1</gravitee-node.version>

--- a/src/main/java/io/gravitee/el/TemplateVariableProvider.java
+++ b/src/main/java/io/gravitee/el/TemplateVariableProvider.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.el;
 
-import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -30,13 +30,13 @@ public interface TemplateVariableProvider {
     void provide(TemplateContext templateContext);
 
     /**
-     * Same as {@link #provide(TemplateContext)} but with a {@link RequestExecutionContext} allowing to have access to the complete request context
+     * Same as {@link #provide(TemplateContext)} but with a {@link HttpExecutionContext} allowing to have access to the complete request context
      * (including request and response) as well as the {@link TemplateEngine} and {@link TemplateContext}.
      * It offers more flexibility to the template variable provider when it comes to provide template variables that are coming from the current execution context.
      *
      * @param ctx the current request execution context.
      */
-    default void provide(RequestExecutionContext ctx) {
+    default <T extends HttpExecutionContext> void provide(T ctx) {
         provide(ctx.getTemplateEngine().getTemplateContext());
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8229
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.11.0-feat-endpoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/1.11.0-feat-endpoint-SNAPSHOT/gravitee-expression-language-1.11.0-feat-endpoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
