### PR TITLE
fix: properly handle brackets in evaluated expressions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,23 @@
 
     <properties>
         <json-path.version>2.6.0</json-path.version>
+        <junit-jupiter.version>5.9.0</junit-jupiter.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-gateway-api.version>1.32.4</gravitee-gateway-api.version>
         <jmh.version>1.21</jmh.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -92,8 +105,13 @@
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
+++ b/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
@@ -33,9 +33,13 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  */
 public class SpelTemplateEngine implements TemplateEngine {
 
-    private static final String EXPRESSION_REGEX = "\\{( *[^#T\\( 0-9])";
+    // This transforms expressions prefixes from user input : {#, {(, or {T
+    // By prefixes that will be well interpreted by our TemplateParserContext : {##, {#(, or {#T
+    // regular '{' characters won't be interpreted as expression prefixes by EL SpelExpressionParser
+    private static final String EXPRESSION_REGEX = "\\{ *([#T(])";
     private static final Pattern EXPRESSION_REGEX_PATTERN = Pattern.compile(EXPRESSION_REGEX);
-    private static final String EXPRESSION_REGEX_SUBSTITUTE = "{'{'}$1";
+    private static final String EXPRESSION_REGEX_SUBSTITUTE = "{#$1";
+
     private static final ParserContext PARSER_CONTEXT = new TemplateParserContext();
     private static final SpelExpressionParser EXPRESSION_PARSER = new SpelExpressionParser(
         new SpelParserConfiguration(SpelCompilerMode.MIXED, null)

--- a/src/main/java/io/gravitee/el/spel/TemplateParserContext.java
+++ b/src/main/java/io/gravitee/el/spel/TemplateParserContext.java
@@ -25,7 +25,7 @@ public class TemplateParserContext implements ParserContext {
 
     @Override
     public String getExpressionPrefix() {
-        return "{";
+        return "{#";
     }
 
     @Override

--- a/src/main/resources/whitelist
+++ b/src/main/resources/whitelist
@@ -76,5 +76,6 @@ method java.util.TimeZone getTimeZone java.lang.String
 method java.util.UUID randomUUID
 method io.gravitee.common.util.MultiValueMap toSingleValueMap
 method io.gravitee.common.util.MultiValueMap getFirst java.lang.Object
+method io.gravitee.common.util.MultiValueMap containsAllKeys java.util.Collection
 
 # Allows by constructor signatures

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
@@ -659,6 +659,18 @@ public class SpelTemplateEngineTest {
     }
 
     @Test
+    public void shouldHeadersContainsAllKeys() {
+        final HttpHeaders headers = HttpHeaders.create().add("Header1", "value1").add("Header2", "value2");
+        when(request.headers()).thenReturn(headers);
+
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("request", new EvaluableRequest(request));
+
+        assertTrue(engine.getValue("{ #request.headers.containsAllKeys({'Header1', 'Header2'}) }", Boolean.class));
+        assertFalse(engine.getValue("{ #request.headers.containsAllKeys({'Header1', 'Header2', 'Header3'}) }", Boolean.class));
+    }
+
+    @Test
     public void shouldGetValueAsBoolean() {
         final HttpHeaders headers = HttpHeaders.create().add("X-Gravitee-Endpoint", "true");
 


### PR DESCRIPTION
Before this fix, `{` is the expression prefix of the EL engine.
As this character can be in regular strings, out of any expression language, they are replaced with `{'{'}` which is a interpreted as a list of one `{` character during expression evaluation.
That causes problems when `{` is, as a string, inside a expression language function parameter, for example `{#request.pathInfo.matches('/[A-Z]{2}')}` : the `{2}` shouldn't be escaped.

With this fix, `{#` is the expression prefix of the EL engine.
EL prefixes from user input : `{#`, `{(`, or `{T` are replaced by `{##`, `{#(`, or `{#T`. Regular `{` characters aren't interpreted as expression prefixes by EL SpelExpressionParser

**Issue**

https://github.com/gravitee-io/issues/issues/8367
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.6-fix-bracketsEscaping-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/1.9.6-fix-bracketsEscaping-SNAPSHOT/gravitee-expression-language-1.9.6-fix-bracketsEscaping-SNAPSHOT.zip)
  <!-- Version placeholder end -->
