### PR TITLE
Merge `1.9.x` into `master`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.11.0](https://github.com/gravitee-io/gravitee-expression-language/compare/1.10.1...1.11.0) (2022-08-17)
+
+
+### Features
+
+* use higher level HttpExecutionContext for TemplateProvider ([8cdc319](https://github.com/gravitee-io/gravitee-expression-language/commit/8cdc31911d2658339ca8cd9cf72c9743870e5485))
+
 ## [1.10.1](https://github.com/gravitee-io/gravitee-expression-language/compare/1.10.0...1.10.1) (2022-06-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.10.1](https://github.com/gravitee-io/gravitee-expression-language/compare/1.10.0...1.10.1) (2022-06-21)
+
+
+### Bug Fixes
+
+* **spel:** catch parsing exception and return Maybe on error ([5d74a94](https://github.com/gravitee-io/gravitee-expression-language/commit/5d74a94b3fb3f749147b62446f00ea46a6224f6a))
+
 # [1.10.0](https://github.com/gravitee-io/gravitee-expression-language/compare/1.9.2...1.10.0) (2022-06-20)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.el</groupId>
     <artifactId>gravitee-expression-language</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
 
     <name>Gravitee.io Common - Expression language module</name>
     <description>Gravitee.io Common - Expression language module</description>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>0.18</version>
                 <configuration>
                     <nodeVersion>12.13.0</nodeVersion>
                     <prettierJavaVersion>1.6.1</prettierJavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.el</groupId>
     <artifactId>gravitee-expression-language</artifactId>
-    <version>1.10.1</version>
+    <version>1.11.0</version>
 
     <name>Gravitee.io Common - Expression language module</name>
     <description>Gravitee.io Common - Expression language module</description>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>2.5</gravitee-bom.version>
         <json-path.version>2.6.0</json-path.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
-        <gravitee-gateway-api.version>1.34.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.40.0</gravitee-gateway-api.version>
         <jmh.version>1.35</jmh.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
         <gravitee-node.version>1.24.1</gravitee-node.version>

--- a/src/main/java/io/gravitee/el/TemplateVariableProvider.java
+++ b/src/main/java/io/gravitee/el/TemplateVariableProvider.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.el;
 
-import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -30,13 +30,13 @@ public interface TemplateVariableProvider {
     void provide(TemplateContext templateContext);
 
     /**
-     * Same as {@link #provide(TemplateContext)} but with a {@link RequestExecutionContext} allowing to have access to the complete request context
+     * Same as {@link #provide(TemplateContext)} but with a {@link HttpExecutionContext} allowing to have access to the complete request context
      * (including request and response) as well as the {@link TemplateEngine} and {@link TemplateContext}.
      * It offers more flexibility to the template variable provider when it comes to provide template variables that are coming from the current execution context.
      *
      * @param ctx the current request execution context.
      */
-    default void provide(RequestExecutionContext ctx) {
+    default <T extends HttpExecutionContext> void provide(T ctx) {
         provide(ctx.getTemplateEngine().getTemplateContext());
     }
 }

--- a/src/main/java/io/gravitee/el/spel/SpelExpressionParser.java
+++ b/src/main/java/io/gravitee/el/spel/SpelExpressionParser.java
@@ -29,6 +29,7 @@ import org.springframework.expression.spel.SpelParserConfiguration;
  * @author GraviteeSource Team
  */
 public class SpelExpressionParser {
+
     private static final String EXPRESSION_PREFIX = "{#";
     private static final String EXPRESSION_SUFFIX = "}";
     // This transforms expressions prefixes from user input : {#, {(, or {T
@@ -36,7 +37,7 @@ public class SpelExpressionParser {
     // regular '{' characters won't be interpreted as expression prefixes by EL SpelExpressionParser
     private static final String EXPRESSION_REGEX = "\\{ *([#T(])";
     private static final Pattern EXPRESSION_REGEX_PATTERN = Pattern.compile(EXPRESSION_REGEX);
-    private static final String EXPRESSION_REGEX_SUBSTITUTE = EXPRESSION_PREFIX  + "$1";
+    private static final String EXPRESSION_REGEX_SUBSTITUTE = EXPRESSION_PREFIX + "$1";
     private static final ParserContext PARSER_CONTEXT = new TemplateParserContext(EXPRESSION_PREFIX, EXPRESSION_SUFFIX);
     private static final org.springframework.expression.spel.standard.SpelExpressionParser EXPRESSION_PARSER = new org.springframework.expression.spel.standard.SpelExpressionParser(
         new SpelParserConfiguration(SpelCompilerMode.MIXED, null)


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8479

**Description**

Merge `1.9.x` into `master`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.11.2-merge-1-9-x-into-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/1.11.2-merge-1-9-x-into-master-SNAPSHOT/gravitee-expression-language-1.11.2-merge-1-9-x-into-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
