### PR TITLE
fix: handle nested EL expressions

### DIFF
--- a/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
+++ b/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
@@ -36,9 +36,9 @@ public class SpelTemplateEngine implements TemplateEngine {
     // This transforms expressions prefixes from user input : {#, {(, or {T
     // By prefixes that will be well interpreted by our TemplateParserContext : {##, {#(, or {#T
     // regular '{' characters won't be interpreted as expression prefixes by EL SpelExpressionParser
-    private static final String EXPRESSION_REGEX = "\\{ *([#T(])";
+    private static final String EXPRESSION_REGEX = "\\{ *([#T(])((?>[^{}]+|\\{(?>[^{}]+)*\\})*\\})";
     private static final Pattern EXPRESSION_REGEX_PATTERN = Pattern.compile(EXPRESSION_REGEX);
-    private static final String EXPRESSION_REGEX_SUBSTITUTE = "{#$1";
+    private static final String EXPRESSION_REGEX_SUBSTITUTE = "{#$1$2";
 
     private static final ParserContext PARSER_CONTEXT = new TemplateParserContext();
     private static final SpelExpressionParser EXPRESSION_PARSER = new SpelExpressionParser(

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
@@ -777,7 +777,9 @@ public class SpelTemplateEngineTest {
             Arguments.of("{2} {  #  request.pathInfo.matches ( '/my/path/[A-Z]{2}[0-9]{2}')} {3}", "{2} false {3}"),
             Arguments.of("{ '/my/path/A58' == #request.pathInfo}", "{ '/my/path/A58' == #request.pathInfo}"),
             Arguments.of("{('/my/path/A58'==#request.pathInfo)}", "true"),
-            Arguments.of("{('/my/path/A59'==#request.pathInfo)}", "false")
+            Arguments.of("{('/my/path/A59'==#request.pathInfo)}", "false"),
+            Arguments.of("{T(java.lang.String).format(\"XX%sXX\", #request.pathInfo)}", "XX/my/path/A58XX"),
+            Arguments.of("{T(java.lang.String).format(\"XX%sXX\", {#request.pathInfo})}", "XX/my/path/A58XX")
         );
     }
 


### PR DESCRIPTION
fix: handle nested EL expressions

Last version of EL plugin doesn’t accept nested EL expressions nomore. This bugfix restores nested EL support.

This permit usage of both syntaxes :
- Not nested : {#request.headers[#properties.header]}
- Nested : {#request.headers[{#properties.header}]}

The replacement regexp has changed as it NOT replaces `{#` EL prefixes which are nested into another EL expression.

**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-165
