### PR TITLE
fix: bump gateway-api as we don't mix rxJava versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>2.7</gravitee-bom.version>
         <json-path.version>2.6.0</json-path.version>
         <gravitee-common.version>2.0.0-alpha.1</gravitee-common.version>
-        <gravitee-gateway-api.version>1.40.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.0.0-alpha.1</gravitee-gateway-api.version>
         <jmh.version>1.35</jmh.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
         <gravitee-node.version>2.0.0-alpha.3</gravitee-node.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7990
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-chore-bumpGatewayApi-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/2.0.0-chore-bumpGatewayApi-SNAPSHOT/gravitee-expression-language-2.0.0-chore-bumpGatewayApi-SNAPSHOT.zip)
  <!-- Version placeholder end -->
