### PR TITLE
chore: bump `gravitee-node` to 1.27.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <gravitee-gateway-api.version>1.40.0</gravitee-gateway-api.version>
         <jmh.version>1.35</jmh.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
-        <gravitee-node.version>1.24.1</gravitee-node.version>
+        <gravitee-node.version>1.27.3</gravitee-node.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Issue**

NA

**Description**

Bump `gravitee-node` to 1.27.3
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.11.3`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/1.11.3/gravitee-expression-language-1.11.3.zip)
  <!-- Version placeholder end -->
