### PR TITLE
fix: use a release version of gateway-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>2.7</gravitee-bom.version>
         <json-path.version>2.6.0</json-path.version>
         <gravitee-common.version>2.0.0</gravitee-common.version>
-        <gravitee-gateway-api.version>2.0.0-alpha.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.0.0</gravitee-gateway-api.version>
         <jmh.version>1.35</jmh.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
         <gravitee-node.version>2.0.0</gravitee-node.version>
@@ -178,8 +178,7 @@
                 <artifactId>prettier-maven-plugin</artifactId>
                 <version>0.18</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                    <prettierJavaVersion>1.6.2</prettierJavaVersion>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Bump version of gravitee-gateway-api + fix prettier maven plugin
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-bump-gateway-api-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/2.0.1-bump-gateway-api-version-SNAPSHOT/gravitee-expression-language-2.0.1-bump-gateway-api-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
