### PR TITLE
chore: rename 'jupiter' package in 'reactive'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>2.7</gravitee-bom.version>
         <json-path.version>2.6.0</json-path.version>
         <gravitee-common.version>2.0.0</gravitee-common.version>
-        <gravitee-gateway-api.version>2.0.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-apim-718-rename-v4-terms-SNAPSHOT</gravitee-gateway-api.version>
         <jmh.version>1.35</jmh.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
         <gravitee-node.version>2.0.0</gravitee-node.version>

--- a/src/main/java/io/gravitee/el/TemplateVariableProvider.java
+++ b/src/main/java/io/gravitee/el/TemplateVariableProvider.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.el;
 
-import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)


### PR DESCRIPTION
related to APIM-718

* Rename jupiter package into reactive
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/2.0.1/gravitee-expression-language-2.0.1.zip)
  <!-- Version placeholder end -->
