### PR TITLE
feat: bump gravitee-node to use latest cache plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.el</groupId>
     <artifactId>gravitee-expression-language</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0-archi-231-cache-manager-SNAPSHOT</version>
 
     <name>Gravitee.io Common - Expression language module</name>
     <description>Gravitee.io Common - Expression language module</description>
@@ -40,7 +40,7 @@
         <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <jmh.version>1.36</jmh.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
-        <gravitee-node.version>2.0.0</gravitee-node.version>
+        <gravitee-node.version>3.1.0-alpha.5</gravitee-node.version>
     </properties>
 
     <dependencyManagement>
@@ -106,7 +106,12 @@
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-cache</artifactId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${gravitee-node.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-cache-common</artifactId>
             <version>${gravitee-node.version}</version>
         </dependency>
 

--- a/src/main/java/io/gravitee/el/spel/SpelExpressionParser.java
+++ b/src/main/java/io/gravitee/el/spel/SpelExpressionParser.java
@@ -17,7 +17,7 @@ package io.gravitee.el.spel;
 
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheConfiguration;
-import io.gravitee.node.cache.standalone.StandaloneCache;
+import io.gravitee.node.plugin.cache.common.InMemoryCache;
 import java.util.regex.Pattern;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParserContext;
@@ -49,11 +49,13 @@ public class SpelExpressionParser {
     private static final int CACHE_EXPRESSION_IDLE_SECONDS = 3600;
 
     static {
-        final CacheConfiguration cacheConfiguration = new CacheConfiguration();
-        cacheConfiguration.setMaxSize(CACHE_EXPRESSION_MAX_SIZE);
-        cacheConfiguration.setTimeToIdleSeconds(CACHE_EXPRESSION_IDLE_SECONDS);
+        final CacheConfiguration cacheConfiguration = CacheConfiguration
+            .builder()
+            .maxSize(CACHE_EXPRESSION_MAX_SIZE)
+            .timeToIdleInMs(CACHE_EXPRESSION_IDLE_SECONDS)
+            .build();
 
-        expressions = new StandaloneCache<>("el", cacheConfiguration);
+        expressions = new InMemoryCache<>("el", cacheConfiguration);
     }
 
     public CachedExpression parseAndCacheExpression(String expression) {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-231

**Description**

Use newest cache manager plugin


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-archi-231-cache-manager-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/2.2.0-archi-231-cache-manager-SNAPSHOT/gravitee-expression-language-2.2.0-archi-231-cache-manager-SNAPSHOT.zip)
  <!-- Version placeholder end -->
