### PR TITLE
fix: define classloader in the SpelParser config to avoid exception i…

### DIFF
--- a/src/main/java/io/gravitee/el/spel/SpelExpressionParser.java
+++ b/src/main/java/io/gravitee/el/spel/SpelExpressionParser.java
@@ -18,11 +18,12 @@ package io.gravitee.el.spel;
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.plugin.cache.common.InMemoryCache;
-import java.util.regex.Pattern;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParserContext;
 import org.springframework.expression.spel.SpelCompilerMode;
 import org.springframework.expression.spel.SpelParserConfiguration;
+
+import java.util.regex.Pattern;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -39,20 +40,18 @@ public class SpelExpressionParser {
     private static final Pattern EXPRESSION_REGEX_PATTERN = Pattern.compile(EXPRESSION_REGEX);
     private static final String EXPRESSION_REGEX_SUBSTITUTE = EXPRESSION_PREFIX + "$1$2";
     private static final ParserContext PARSER_CONTEXT = new TemplateParserContext(EXPRESSION_PREFIX, EXPRESSION_SUFFIX);
-    private static final org.springframework.expression.spel.standard.SpelExpressionParser EXPRESSION_PARSER = new org.springframework.expression.spel.standard.SpelExpressionParser(
-        new SpelParserConfiguration(SpelCompilerMode.MIXED, null)
-    );
+    private org.springframework.expression.spel.standard.SpelExpressionParser expressionParser;
 
     protected static final Cache<String, CachedExpression> expressions;
 
     private static final int CACHE_EXPRESSION_MAX_SIZE = 20000;
-    private static final int CACHE_EXPRESSION_IDLE_SECONDS = 3600;
+    private static final int CACHE_EXPRESSION_IDLE_MILLIS = 3600000;
 
     static {
         final CacheConfiguration cacheConfiguration = CacheConfiguration
             .builder()
             .maxSize(CACHE_EXPRESSION_MAX_SIZE)
-            .timeToIdleInMs(CACHE_EXPRESSION_IDLE_SECONDS)
+            .timeToIdleInMs(CACHE_EXPRESSION_IDLE_MILLIS)
             .build();
 
         expressions = new InMemoryCache<>("el", cacheConfiguration);
@@ -71,9 +70,18 @@ public class SpelExpressionParser {
     }
 
     public Expression parseExpression(String expression) {
-        return EXPRESSION_PARSER.parseExpression(
-            EXPRESSION_REGEX_PATTERN.matcher(expression).replaceAll(EXPRESSION_REGEX_SUBSTITUTE),
-            PARSER_CONTEXT
-        );
+        return getParser()
+            .parseExpression(EXPRESSION_REGEX_PATTERN.matcher(expression).replaceAll(EXPRESSION_REGEX_SUBSTITUTE), PARSER_CONTEXT);
+    }
+
+    private org.springframework.expression.spel.standard.SpelExpressionParser getParser() {
+        if (expressionParser == null) {
+            expressionParser =
+                new org.springframework.expression.spel.standard.SpelExpressionParser(
+                    new SpelParserConfiguration(SpelCompilerMode.MIXED, this.getClass().getClassLoader())
+                );
+        }
+
+        return expressionParser;
     }
 }


### PR DESCRIPTION
…n the reactive eval method

fixes APIM-1669

**Description**

When the reactive eval method is used, the Thread that execute the expression parsing may not have the right classloader.
That can lead to a ClassNotFound exception when the Spel engine compile the expression.
To fix this, the parser config is initialized using the ClassCloader of the gravitee SpelExpressionParser that has been created with a classloader referencing all the gravitee dependencies
