### PR TITLE
feat: update whitelist to include base64 encoding classes

### DIFF
--- a/src/main/resources/whitelist
+++ b/src/main/resources/whitelist
@@ -19,6 +19,9 @@ class java.text.NumberFormat
 class java.text.ChoiceFormat
 class java.text.DecimalFormat
 class java.text.MessageFormat
+class java.util.Base64
+class java.util.Base64.Encoder
+class java.util.Base64.Decoder
 
 class java.util.Calendar
 

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
@@ -33,6 +33,7 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -615,6 +616,28 @@ public class SpelTemplateEngineTest {
         final TemplateEngine engine = TemplateEngine.templateEngine();
         final TestObserver<Boolean> obs = engine.eval("{ (#timestamp > 2) && (#timestamp < 2) }", Boolean.class).test();
         obs.assertResult(false);
+    }
+
+    @Test
+    public void shouldEvaluateBase64Encoding() {
+        String original = "original";
+        final String expected = Base64.getEncoder().encodeToString(original.getBytes());
+        final TemplateEngine engine = TemplateEngine.templateEngine();
+        engine
+            .eval("{ T(java.util.Base64).getEncoder().encodeToString('original'.getBytes()) }", String.class)
+            .test()
+            .assertResult(expected);
+    }
+
+    @Test
+    public void shouldEvaluateBase64Decoding() {
+        String original = "original";
+        final String encoded = Base64.getEncoder().encodeToString(original.getBytes());
+        final TemplateEngine engine = TemplateEngine.templateEngine();
+        engine
+            .eval("{(new java.lang.String(T(java.util.Base64).getDecoder().decode('" + encoded + "'))) }", String.class)
+            .test()
+            .assertResult(original);
     }
 
     @Test


### PR DESCRIPTION
**Description**

base64 encoding is a common EL use case so I want this to be included in the default distribution

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.0-bigmike36c-patch-1-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/3.2.0-bigmike36c-patch-1-SNAPSHOT/gravitee-expression-language-3.2.0-bigmike36c-patch-1-SNAPSHOT.zip)
  <!-- Version placeholder end -->
