### PR TITLE
fix: document builder should not be namespace aware as namespace are not extracted from EL

### DIFF
--- a/src/main/java/io/gravitee/el/spel/function/xml/XPathExpressionFactory.java
+++ b/src/main/java/io/gravitee/el/spel/function/xml/XPathExpressionFactory.java
@@ -29,12 +29,9 @@ public class XPathExpressionFactory {
 
     private static final XPathFactory xpathFactory = XPathFactory.newInstance();
 
-    public static XPathExpression createXPathExpression(String expression, Map<String, String> namespaces) {
+    public static XPathExpression createXPathExpression(String expression) {
         try {
             XPath xpath = createXPath();
-            SimpleNamespaceContext namespaceContext = new SimpleNamespaceContext();
-            namespaceContext.setBindings(namespaces);
-            xpath.setNamespaceContext(namespaceContext);
             javax.xml.xpath.XPathExpression xpathExpression = xpath.compile(expression);
             return new XPathExpression(xpathExpression, expression);
         } catch (XPathExpressionException var5) {

--- a/src/test/java/io/gravitee/el/spel/function/xml/XPathTest.java
+++ b/src/test/java/io/gravitee/el/spel/function/xml/XPathTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class XPathTest {
 
     @Test
-    public void shouldExtractValue_xPath() {
+    public void should_extract_value_with_xPath() {
         final String input =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
             "<root>" +
@@ -36,5 +36,26 @@ public class XPathTest {
 
         Object lastname = XPathFunction.evaluate(input, ".//lastname");
         Assertions.assertEquals("DOE", lastname);
+    }
+
+    @Test
+    public void should_extract_child_node_value() {
+        final String input =
+            """
+            <S:Example xmlns:S="http://www.w3.org/2003/05/soap-envelope">
+                <S:Body>
+                    <Foo xmlns:ns2="dummy:example:ns" xmlns="another:dummy:ns">
+                        <Priority>500</Priority>
+                        <ListRessource>
+                            <Ressource>
+                                <Bar>/Baz</Bar>
+                            </Ressource>
+                        </ListRessource>
+                    </Foo>
+                </S:Body>
+            </S:Example>
+        """;
+        var result = XPathFunction.evaluate(input, ".//Bar");
+        Assertions.assertEquals("/Baz", result);
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6587

**Description**

Today some EL using XPath are failing because the document builder is configured to be namespace aware but we always force the namespaces as an empty Map. The goal of this pull request is to ease the usage of xpath by disabling this namespace aware configuration.

Next step in the future will be to think about how to extract the namepaces properly and document what kind of EL using XPath are allowed or not using our product. 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
