### PR TITLE
feat: remove variable provider provide(ctx) method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,13 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>6.0.60</gravitee-bom.version>
+        <gravitee-bom.version>8.1.17</gravitee-bom.version>
         <json-path.version>2.9.0</json-path.version>
-        <gravitee-common.version>3.4.1</gravitee-common.version>
-        <gravitee-gateway-api.version>3.6.0</gravitee-gateway-api.version>
+        <gravitee-common.version>4.5.1</gravitee-common.version>
+        <gravitee-gateway-api.version>3.9.0-alpha.16</gravitee-gateway-api.version>
         <jmh.version>1.37</jmh.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
-        <gravitee-node.version>4.8.7</gravitee-node.version>
+        <gravitee-node.version>7.0.0-alpha.3</gravitee-node.version>
         <guava.version>33.3.1-jre</guava.version>
     </properties>
 

--- a/src/main/java/io/gravitee/el/TemplateVariableProvider.java
+++ b/src/main/java/io/gravitee/el/TemplateVariableProvider.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.el;
 
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
-
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
@@ -28,15 +26,4 @@ public interface TemplateVariableProvider {
      * @param templateContext the template context where to add the variables.
      */
     void provide(TemplateContext templateContext);
-
-    /**
-     * Same as {@link #provide(TemplateContext)} but with a {@link HttpExecutionContext} allowing to have access to the complete request context
-     * (including request and response) as well as the {@link TemplateEngine} and {@link TemplateContext}.
-     * It offers more flexibility to the template variable provider when it comes to provide template variables that are coming from the current execution context.
-     *
-     * @param ctx the current request execution context.
-     */
-    default <T extends HttpExecutionContext> void provide(T ctx) {
-        provide(ctx.getTemplateEngine().getTemplateContext());
-    }
 }


### PR DESCRIPTION


**Issue**

BREAKING CHANGE: classes overriding TemplateVariableProvider#provide(ExecutionContext) will be to update the signature https://gravitee.atlassian.net/browse/APIM-7417

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-apim-7417-refactor-el-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/4.0.0-apim-7417-refactor-el-SNAPSHOT/gravitee-expression-language-4.0.0-apim-7417-refactor-el-SNAPSHOT.zip)
  <!-- Version placeholder end -->
