### PR TITLE
feat: allow evaluating EL synchronously

### DIFF
--- a/src/main/java/io/gravitee/el/TemplateEngine.java
+++ b/src/main/java/io/gravitee/el/TemplateEngine.java
@@ -57,13 +57,25 @@ public interface TemplateEngine {
      *
      * @return the result of the evaluation.
      * @see #eval(String, Class)
-     * @deprecated this method is deprecated in favor of {@link #eval(String, Class)} that supports reactive.
+     * @deprecated this method is deprecated in favor of {@link #eval(String, Class)} or {@link #evalNow(String, Class)}.
      */
     @Deprecated(since = "1.10.0", forRemoval = true)
     <T> T getValue(String expression, Class<T> clazz);
 
     /**
      * Evaluate the el expression against the current template context.
+     *
+     * @param expression the el expression to evaluate.
+     * @param clazz the class of the expected result .
+     * @param <T> the expected result type.
+     *
+     * @return the result of the evaluation.
+     * @see #eval(String, Class)
+     */
+    <T> T evalNow(String expression, Class<T> clazz);
+
+    /**
+     * Evaluate the el expression against the current template context in a reactive context.
      *
      * @param expression the el expression to evaluate.
      * @param clazz the class of the expected result .

--- a/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
+++ b/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
@@ -41,6 +41,11 @@ public class SpelTemplateEngine implements TemplateEngine {
 
     @Override
     public <T> T getValue(String expression, Class<T> clazz) {
+        return evalNow(expression, clazz);
+    }
+
+    @Override
+    public <T> T evalNow(String expression, Class<T> clazz) {
         return eval(spelExpressionParser.parseExpression(expression), templateContext.getContext(), clazz);
     }
 

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
@@ -707,8 +707,8 @@ public class SpelTemplateEngineTest {
         TemplateEngine engine = TemplateEngine.templateEngine();
         engine.getTemplateContext().setVariable("request", new EvaluableRequest(request));
 
-        assertTrue(engine.getValue("{ #request.headers.containsAllKeys({'Header1', 'Header2'}) }", Boolean.class));
-        assertFalse(engine.getValue("{ #request.headers.containsAllKeys({'Header1', 'Header2', 'Header3'}) }", Boolean.class));
+        assertTrue(engine.evalNow("{ #request.headers.containsAllKeys({'Header1', 'Header2'}) }", Boolean.class));
+        assertFalse(engine.evalNow("{ #request.headers.containsAllKeys({'Header1', 'Header2', 'Header3'}) }", Boolean.class));
     }
 
     @Test
@@ -751,7 +751,7 @@ public class SpelTemplateEngineTest {
         final TemplateEngine engine = TemplateEngine.templateEngine();
         engine.getTemplateContext().setVariable("request", new EvaluableRequest(request));
 
-        assertTrue(engine.getValue("{#request.pathInfo.matches('" + regex + "')}", Boolean.class));
+        assertTrue(engine.evalNow("{#request.pathInfo.matches('" + regex + "')}", Boolean.class));
     }
 
     @Test
@@ -767,7 +767,7 @@ public class SpelTemplateEngineTest {
         final TemplateEngine engine = TemplateEngine.templateEngine();
         engine.getTemplateContext().setVariable("request", new EvaluableRequest(request));
 
-        assertTrue(engine.getValue("{#request.pathInfo.matches('" + regex + "')}", Boolean.class));
+        assertTrue(engine.evalNow("{#request.pathInfo.matches('" + regex + "')}", Boolean.class));
     }
 
     @ParameterizedTest
@@ -784,7 +784,7 @@ public class SpelTemplateEngineTest {
         }
     )
     void shouldEvaluateSimpleStringWithoutExpressions(String expression) {
-        final String evaluatedExpression = TemplateEngine.templateEngine().getValue(expression, String.class);
+        final String evaluatedExpression = TemplateEngine.templateEngine().evalNow(expression, String.class);
         assertEquals(expression, evaluatedExpression);
     }
 
@@ -806,7 +806,7 @@ public class SpelTemplateEngineTest {
     @ParameterizedTest
     @MethodSource("expressionsWithoutVariables")
     void shouldEvaluateStringWithExpression(String expression, String expectedResult) {
-        final String evaluatedExpression = TemplateEngine.templateEngine().getValue(expression, String.class);
+        final String evaluatedExpression = TemplateEngine.templateEngine().evalNow(expression, String.class);
         assertEquals(expectedResult, evaluatedExpression);
     }
 
@@ -832,7 +832,7 @@ public class SpelTemplateEngineTest {
         final TemplateEngine engine = TemplateEngine.templateEngine();
         engine.getTemplateContext().setVariable("request", new EvaluableRequest(request));
 
-        final String evaluatedExpression = engine.getValue(expression, String.class);
+        final String evaluatedExpression = engine.evalNow(expression, String.class);
         assertEquals(expectedResult, evaluatedExpression);
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-548

**Description**

Since the beginning of the v4, we’ve made some evolutions on the 
template engine to support evaluation in a reactive way. At the time, we
decided to deprecate blocking getValue() and convert() methods and force
using the reactive eval() method instead.

We now think that non-reactive evaluation of EL expression can still
make sense when resolving an EL expression outside of the context of an
API call:

It offers better performances when evaluating simple EL expressions.

It allows us to keep simplicity. Especially when you need to evaluate an
EL outside of a reactive chain.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-apim548-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/4.0.0-apim548-SNAPSHOT/gravitee-expression-language-4.0.0-apim548-SNAPSHOT.zip)
  <!-- Version placeholder end -->
