### PR TITLE
fix: template variable discovery failed to find them all

### DIFF
--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,4 +1,0 @@
-io.gravitee.el.TemplateVariableProvider=\
-    io.gravitee.el.spel.TemplateVariableFactoryTest.APITemplateVariableProvider,\
-  io.gravitee.el.spel.TemplateVariableFactoryTest.UnAnnotatedTestTemplateProvider,\
-  io.gravitee.el.spel.TemplateVariableFactoryTest.WrongScopeTemplateVariableProvider


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-8416

**Description**
Changes where made to remove deprecated String API but the replacement was loading new bean instead of the one created by `META-INF/spring.factories` files, hide some `TemplateVariableProvider`. 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-fix-dictionary-el-variable-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/4.0.1-fix-dictionary-el-variable-SNAPSHOT/gravitee-expression-language-4.0.1-fix-dictionary-el-variable-SNAPSHOT.zip)
  <!-- Version placeholder end -->
