### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>8.2.10</gravitee-bom.version>
         <json-path.version>2.9.0</json-path.version>
         <gravitee-common.version>4.6.0</gravitee-common.version>
-        <gravitee-gateway-api.version>3.9.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.11.1</gravitee-gateway-api.version>
         <jmh.version>1.37</jmh.version>
         <bcpkix-jdk18on.version>1.78.1</bcpkix-jdk18on.version>
         <gravitee-node.version>7.0.7</gravitee-node.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <gravitee-gateway-api.version>3.9.0</gravitee-gateway-api.version>
         <jmh.version>1.37</jmh.version>
         <bcpkix-jdk18on.version>1.78.1</bcpkix-jdk18on.version>
-        <gravitee-node.version>7.0.0</gravitee-node.version>
+        <gravitee-node.version>7.0.7</gravitee-node.version>
         <guava.version>33.4.0-jre</guava.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-gateway-api.version>3.9.0</gravitee-gateway-api.version>
         <jmh.version>1.37</jmh.version>
-        <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
+        <bcpkix-jdk18on.version>1.78.1</bcpkix-jdk18on.version>
         <gravitee-node.version>7.0.0</gravitee-node.version>
         <guava.version>33.4.0-jre</guava.version>
     </properties>
@@ -60,8 +60,8 @@
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>${bcpkix-jdk15on.version}</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bcpkix-jdk18on.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Description**

Bump dependencies

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.2-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/4.0.2-bump-dependencies-SNAPSHOT/gravitee-expression-language-4.0.2-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
