### PR TITLE
fix(deps): define json-smart dependency to force version 2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <properties>
         <gravitee-bom.version>8.2.10</gravitee-bom.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-gateway-api.version>3.11.1</gravitee-gateway-api.version>
@@ -81,6 +82,12 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>${json-path.version}</version>
+        </dependency>
+        <!-- Force json-smart to override the version used by json-path until https://github.com/json-path/JsonPath/pull/1030 is merged -->
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${json-smart.version}</version>
         </dependency>
 
         <!-- Logging -->


### PR DESCRIPTION
**Description**

`json-path` library is still not updated to use the fixed version of `json-smart`. This commit defines explicitly the `json-smart` library to force the use of 2.5.2.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.3-override-json-smart-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/4.0.3-override-json-smart-version-SNAPSHOT/gravitee-expression-language-4.0.3-override-json-smart-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
