### PR TITLE
feat: add support for reactive functions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,3 @@
-
 = Gravitee Expression Language
 
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-expression-language/blob/master/LICENSE.txt"]
@@ -6,7 +5,142 @@ image:https://img.shields.io/badge/semantic--release-conventional%20commits-e100
 image:https://circleci.com/gh/gravitee-io/gravitee-expression-language.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-expression-language"]
 image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
 
-
 == Description
-This project provides a custom template engine that can be used to parse https://docs.gravitee.io/apim/3.x/apim_publisherguide_expression_language.html[Expression Language] elements.
 
+This project provides a custom template engine for parsing https://documentation.gravitee.io/apim/getting-started/gravitee-expression-language[Expression Language] elements.
+
+== Usage
+
+=== Basic Usage
+
+EL expressions can be evaluated using a `TemplateEngine` instance:
+
+[source,java]
+----
+TemplateEngine engine = TemplateEngine.templateEngine();
+----
+
+To pass variables to the `TemplateEngine`, use its context:
+
+[source,java]
+----
+TemplateEngine engine = TemplateEngine.templateEngine();
+TemplateContext context = engine.getTemplateContext();
+
+context.setVariable("myVar", "myValue");
+----
+
+The context remains available for any evaluated expression. You can evaluate an EL expression against your `TemplateEngine` instance. The first argument is the EL expression, and the second is the expected result type.
+
+[source,java]
+----
+TemplateEngine engine = TemplateEngine.templateEngine();
+TemplateContext context = engine.getTemplateContext();
+
+context.setVariable("myVar", "myValue");
+
+engine.evalNow("{#myVar}", String.class); // Result: "myValue"
+engine.evalNow("{#myVar.isEmpty()}", Boolean.class); // Result: false
+----
+
+IMPORTANT: Ensure the expected result type matches the evaluated expression.
+
+=== Calling Functions
+
+A variable can be of any type and may expose functions:
+
+[source,java]
+----
+// Assign a user variable.
+context.setVariable("myUser", new User("firstname", "lastname"));
+
+engine.eval("{#myUser.getDisplayName()}", String.class); // Calls getDisplayName() on the User instance.
+----
+
+IMPORTANT: You must explicitly declare the `User.getDisplayName()` function in the whitelist of authorized methods. See <<EL Sandbox>> for details.
+
+=== Reactive Usage
+
+To evaluate an EL expression reactively, use `eval()` or instead of `evalNow()`.
+
+IMPORTANT: evalNow() is not strictly equivalent to `eval()` as it does not rely on reactive stack and does not support deferred variable or reactive functions. Hence, `evalNow()` is not suitable for advanced usages such as evaluating an expression based on the content of the request or response body (e.g: `{#request.content}`). However, `evalNow()` remains suitable when evaluating expressions outside a request processing (e.g. API or Security Domain deployment, connector initialization, ...).
+
+[source,java]
+----
+context.setVariable("myVar", "myValue");
+
+engine.eval("{#myVar}", String.class); // Returns Maybe<String>
+engine.eval("{#myVar.isEmpty()}", Boolean.class); // Returns Maybe<Boolean>
+----
+
+==== Deferred Variables
+
+The `TemplateEngine` allows assigning **deferred variables**, useful for injecting values that must be fetched before evaluation. A deferred variable can be a `Maybe` or a `Single`.
+
+[source,java]
+----
+// Assigns a variable from an HTTP call.
+context.setDeferredVariable("myVar", httpClient.fetch("https://somewhere.com").flatMap(result::message));
+
+engine.eval("{#myVar}", String.class); // Resolves myVar before evaluation.
+----
+
+TIP: A deferred variable is evaluated **only if used** in an expression. In the above example, `{#myVar}` triggers the HTTP call, while `{#anotherVar}` does not.
+
+==== Evaluating Functions Returning `Maybe` or `Single`
+
+If you need to evaluate a function that returns a `Maybe` or `Single`, you must inject a specific implementation of `DeferredFunctionHolder` in the context:
+
+[source,java]
+----
+import io.gravitee.el.spel.context.DeferredFunctionHolder;
+
+class MyDeferredFunctionHolder implements DeferredFunctionHolder {
+    public Maybe<String> resolve(String param) {
+        // ... return a Maybe.
+    }
+
+    public Maybe<String> doSomethingReactive() {
+        // ... return a Maybe.
+    }
+};
+
+// Assigns myHolder in the context.
+context.setDeferredFunctionHolderVariable("myHolder", new MyDeferredFunctionHolder());
+
+engine.eval("{#myHolder.resolve('something')}", String.class); // Handles the Maybe returned by the function call and evaluates the final string.
+
+engine.eval("{#myHolder.doSomethingReactive()}", String.class); // Handles the Maybe returned by the function call and evaluates the final string.
+----
+
+== EL Sandbox
+
+The EL Template Engine includes a built-in sandbox feature, allowing safe execution of EL expressions. The sandbox operates based on a predefined whitelist of allowed methods, fields, and constructors.
+
+=== Whitelist Configuration
+
+The sandbox provides the following configuration options:
+
+* `el.whitelist.mode`: Defines whether to `append` or `replace` the built-in whitelist.
+** `append` (default) - Adds new whitelisted definitions while keeping existing ones.
+** `replace` - Replaces the built-in list entirely (use with caution).
+
+  TIP: Always use `append` unless you are certain you need `replace`.
+
+* `el.whitelist.list`: Specifies additional methods, constructors, fields, or annotations to allow.
+** Prefix with `method` to allow a specific method (full signature required).
+** Prefix with `class` to allow an entire class (all methods, constructors, and fields will be accessible).
+
+==== Example Configuration
+
+[source,yaml]
+----
+el:
+  whitelist:
+    mode: append
+    list:
+      - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+      - class java.time.format.DateTimeFormatter
+----
+
+WARNING: Be cautious when allowing entire classes or methods. Some classes may expose unintended methods, creating security risks.

--- a/src/main/java/io/gravitee/el/TemplateContext.java
+++ b/src/main/java/io/gravitee/el/TemplateContext.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.el;
 
+import io.gravitee.el.spel.context.DeferredFunctionHolder;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -36,7 +37,7 @@ public interface TemplateContext {
      * If the expression evaluated against this template context does not access the <code>name</code> variable, then the deferred variable will not be invoked.
      *
      * Specifying a {@link Completable} allows to define any custom action like populating attributes of an object added to the context (ex: request.content).
-     *  @param name the name of the variable.
+     * @param name the name of the variable.
      * @param deferred a {@link Completable} that will be called if and only if the variable <code>name</code> is accessed by the evaluated expression.
      */
     void setDeferredVariable(String name, Completable deferred);
@@ -44,17 +45,26 @@ public interface TemplateContext {
     /**
      * Same as {@link #setDeferredVariable(String, Completable)} but with a {@link Maybe}.
      * The value of the {@link Maybe} will be added to the context variable under the variable <code>name</code>.
-     *  @param name the name of the variable.
+     * @param name the name of the variable.
      * @param deferred a {@link Maybe} that will be called if and only if the variable <code>name</code> is accessed by the evaluated expression.
      */
     void setDeferredVariable(String name, Maybe<?> deferred);
 
     /**
      * Same as {@link #setDeferredVariable(String, Maybe)} but with a {@link Single}.
-     *  @param name the name of the variable.
+     * @param name the name of the variable.
      * @param deferred a {@link Single} that will be called if and only if the variable <code>name</code> is accessed by the evaluated expression.
      */
     void setDeferredVariable(String name, Single<?> deferred);
+
+    /**
+     * Set a deferred function holder variable. A {@link DeferredFunctionHolder} is an object that is known to expose one or more reactive methods.
+     * Such an object is simply an holder allowing access to a set of function returning a {@link Maybe} or a {@link Single} that needs to be resolved when evaluating the EL.
+     *
+     * @param name the name of the variable.
+     * @param deferredFunctionHolder an object exposing reactive function (e.g. returning {@link Maybe} or {@link Single}).
+     */
+    void setDeferredFunctionHolderVariable(String name, DeferredFunctionHolder deferredFunctionHolder);
 
     /**
      * Look up a named variable within this evaluation context.

--- a/src/main/java/io/gravitee/el/TemplateEngine.java
+++ b/src/main/java/io/gravitee/el/TemplateEngine.java
@@ -16,6 +16,7 @@
 package io.gravitee.el;
 
 import io.gravitee.common.util.ServiceLoaderHelper;
+import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.reactivex.rxjava3.core.Maybe;
 
 /**
@@ -64,6 +65,7 @@ public interface TemplateEngine {
 
     /**
      * Evaluate the el expression against the current template context.
+     * <b>Warn</b>: <code>evalNow</code> does not support deferred variables and doesn't benefit from cache expression mechanism. Use {@link #eval(String, Class)} for reactive version that supports deferred variables.
      *
      * @param expression the el expression to evaluate.
      * @param clazz the class of the expected result .
@@ -76,6 +78,7 @@ public interface TemplateEngine {
 
     /**
      * Evaluate the el expression against the current template context in a reactive context.
+     * This method supports deferred variables and benefits from a cache of parsed expression.
      *
      * @param expression the el expression to evaluate.
      * @param clazz the class of the expected result .
@@ -84,6 +87,20 @@ public interface TemplateEngine {
      * @return a {@link Maybe} with the result of the evaluation or empty in case the evaluation returns <code>null</code>.
      */
     <T> Maybe<T> eval(String expression, Class<T> clazz);
+
+    /**
+     * Blocking evaluation of the el expression against the current template context in a reactive context.
+     * This method supports deferred variables and benefits from a cache of parsed expression.
+     * <b>Warn</b>: <code>evalBlocking</code> cannot be invoked on the eventloop. This is to avoid possible deadlock. In that case a {@link ExpressionEvaluationException} will be thrown.
+     *
+     *
+     * @param expression the el expression to evaluate.
+     * @param clazz the class of the expected result .
+     * @param <T> the expected result type.
+     *
+     * @return the result of the evaluation.
+     */
+    <T> T evalBlocking(String expression, Class<T> clazz) throws ExpressionEvaluationException;
 
     /**
      * The context containing all the variables that can be used to evaluate the expressions.

--- a/src/main/java/io/gravitee/el/spel/CachedExpression.java
+++ b/src/main/java/io/gravitee/el/spel/CachedExpression.java
@@ -15,16 +15,17 @@
  */
 package io.gravitee.el.spel;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import static java.util.Collections.emptyMap;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.regex.Pattern;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.CompositeStringExpression;
 import org.springframework.expression.spel.SpelNode;
-import org.springframework.expression.spel.ast.CompoundExpression;
-import org.springframework.expression.spel.ast.PropertyOrFieldReference;
-import org.springframework.expression.spel.ast.VariableReference;
+import org.springframework.expression.spel.ast.*;
 import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.util.DigestUtils;
 
 /**
  * Allows to cache a given {@link Expression} for later reuse.
@@ -36,66 +37,122 @@ import org.springframework.expression.spel.standard.SpelExpression;
 public class CachedExpression {
 
     private final Expression expression;
+    private final SpelExpressionParser parser;
     private Set<String> variables;
+    private Set<String> knownDeferredFunctionHolders;
 
-    public CachedExpression(final Expression expression) {
+    private LinkedHashMap<String, String> expressionsToDefer;
+    private Expression rebuiltExpressionForDefer;
+
+    public CachedExpression(final Expression expression, SpelExpressionParser parser) {
         this.expression = expression;
+        this.parser = parser;
         computeVariables(expression);
     }
 
+    public CachedExpression(final Expression expression, SpelExpressionParser parser, Set<String> knownDeferredFunctionHolders) {
+        this.expression = expression;
+        this.parser = parser;
+        this.knownDeferredFunctionHolders = knownDeferredFunctionHolders;
+
+        computeVariables(expression);
+    }
+
+    public Map<String, String> expressionsToDefer() {
+        if (rebuiltExpressionForDefer == null) {
+            return emptyMap();
+        }
+        return expressionsToDefer;
+    }
+
     private void computeVariables(Expression expression) {
-        if (expression instanceof SpelExpression) {
+        final List<String> deferExpressionsCollector = new ArrayList<>();
+
+        computeVariables(expression, deferExpressionsCollector);
+        computeFinalExpression(expression, deferExpressionsCollector);
+    }
+
+    private void computeVariables(Expression expression, List<String> deferExpressionsCollector) {
+        if (expression instanceof SpelExpression spelExpression) {
             // Ex: "{#request.headers['X-Gravitee-Endpoint']}"
-            computeVariables(((SpelExpression) expression).getAST());
-        } else if (expression instanceof CompositeStringExpression) {
+            computeVariables(spelExpression.getAST(), deferExpressionsCollector);
+        } else if (expression instanceof CompositeStringExpression compositeStringExpression) {
             // Ex: "Header X-Gravitee-Endpoint: {#request.headers['X-Gravitee-Endpoint'][0]}"
-            computeVariables((CompositeStringExpression) expression);
+            computeVariables(compositeStringExpression, deferExpressionsCollector);
         }
         // Could be a LiteralExpression we don't really care, ex: "Hello Gravitee".
     }
 
-    private void computeVariables(CompositeStringExpression expression) {
+    private void computeVariables(CompositeStringExpression expression, List<String> deferExpressionsCollector) {
         // Ex: "Header X-Gravitee-Endpoint: {#request.headers['X-Gravitee-Endpoint'][0]}"
         for (Expression e : expression.getExpressions()) {
-            computeVariables(e);
+            computeVariables(e, deferExpressionsCollector);
         }
     }
 
-    private void computeVariables(CompoundExpression expression) {
-        // Ex: "{#value.content.val1}"
+    private void computeVariables(CompoundExpression expression, List<String> deferExpressionsCollector) {
+        // Ex: "{#value.content.val1.get('val')[0]}"
+        final List<SpelNodeImpl> deferExpressionNodes = new ArrayList<>();
+
         for (int i = 0; i < expression.getChildCount(); i++) {
             final SpelNode node = expression.getChild(i);
-            if (node instanceof VariableReference) {
+            if (node instanceof VariableReference variableReference) {
+                // Ex: "{#value.content.val1}"
+
+                // nodes: [value]
+                deferExpressionNodes.add(variableReference);
+
                 i++;
-                StringBuilder variableName = new StringBuilder(getVariableName((VariableReference) node));
+                StringBuilder variableName = new StringBuilder(getVariableName(variableReference));
                 SpelNode attrNode;
                 while (i < expression.getChildCount() && ((attrNode = expression.getChild(i)) instanceof PropertyOrFieldReference)) {
                     // Iterate over all children, ex: value -> content -> val1
-                    variableName.append(".").append(((PropertyOrFieldReference) attrNode).getName());
+                    PropertyOrFieldReference propertyOrFieldReference = (PropertyOrFieldReference) attrNode;
+                    variableName.append(".").append(propertyOrFieldReference.getName());
+
+                    // nodes: [value, content, val1]
+                    deferExpressionNodes.add(propertyOrFieldReference);
                     i++;
                 }
 
                 i--;
 
                 addVariable(variableName.toString());
+            } else if (node instanceof MethodReference || node instanceof Indexer) {
+                // nodes: [value, content, val1, get('val')]
+                deferExpressionNodes.add((SpelNodeImpl) node);
+
+                // Compute the method, ex: {#value.content.val1.get('val')}.
+                computeVariables(node, deferExpressionsCollector);
+
+                if (deferExpressionNodes.size() > 1) {
+                    // Rebuild defer expression from nodes and add it to the collector, ex: #value.content.val1.get('val').
+                    addDeferExpression(deferExpressionNodes, deferExpressionsCollector);
+                }
             } else {
+                // Literal, FunctionReference, TypeReference, ex: {#value.content.val1.get()[0]}
+                if (deferExpressionNodes.size() > 1) {
+                    // Rebuild defer expression from nodes and add it to the collector, ex: #value.content.val1.get('val').
+                    addDeferExpression(deferExpressionNodes, deferExpressionsCollector);
+                }
+
                 // Could be a method, ex: {#value.content()}.
-                computeVariables(node);
+                computeVariables(node, deferExpressionsCollector);
             }
         }
     }
 
-    private void computeVariables(SpelNode spelNode) {
-        if (spelNode instanceof CompoundExpression) {
+    private void computeVariables(SpelNode spelNode, List<String> deferExpressionsCollector) {
+        if (spelNode instanceof CompoundExpression compoundExpression) {
             // Ex: "{#value.content.val1}"
-            computeVariables((CompoundExpression) spelNode);
-        } else if (spelNode instanceof VariableReference && spelNode.getChildCount() == 0) {
+            computeVariables(compoundExpression, deferExpressionsCollector);
+        } else if (spelNode instanceof VariableReference variableReference && spelNode.getChildCount() == 0) {
             // Ex: "{#value}
-            addVariable(getVariableName((VariableReference) spelNode));
+            addVariable(getVariableName(variableReference));
         } else {
             // Iterate and process all child nodes.
             for (int i = 0; i < spelNode.getChildCount(); i++) {
-                computeVariables(spelNode.getChild(i));
+                computeVariables(spelNode.getChild(i), deferExpressionsCollector);
             }
         }
     }
@@ -112,6 +169,9 @@ public class CachedExpression {
     }
 
     public Expression getExpression() {
+        if (rebuiltExpressionForDefer != null) {
+            return rebuiltExpressionForDefer;
+        }
         return expression;
     }
 
@@ -120,5 +180,87 @@ public class CachedExpression {
             return Collections.emptySet();
         }
         return variables;
+    }
+
+    private void computeFinalExpression(Expression expression, List<String> deferExpressionsCollector) {
+        if (makesUseOfDeferFunctions() && (expression instanceof CompositeStringExpression || deferExpressionsCollector.size() > 0)) {
+            expressionsToDefer = new LinkedHashMap<>();
+
+            String lastDeferVariable = null;
+
+            for (String exp : deferExpressionsCollector) {
+                for (Map.Entry<String, String> e : expressionsToDefer.entrySet()) {
+                    exp = exp.replaceAll(Pattern.quote(e.getValue()), "#" + e.getKey());
+                }
+
+                lastDeferVariable = "_" + DigestUtils.md5DigestAsHex(exp.getBytes(StandardCharsets.UTF_8));
+                expressionsToDefer.put(lastDeferVariable, exp);
+            }
+
+            final StringBuilder finalExpressionBuilder = new StringBuilder();
+
+            if (expression instanceof CompositeStringExpression compositeStringExpression) {
+                for (Expression e : compositeStringExpression.getExpressions()) {
+                    if (e instanceof SpelExpression spelExpression) {
+                        finalExpressionBuilder.append("{").append(spelExpression.toStringAST()).append("}");
+                    } else {
+                        finalExpressionBuilder.append(e.getExpressionString());
+                    }
+                }
+            } else if (expression instanceof SpelExpression spelExpression) {
+                if (!(spelExpression.getAST().getChild(0) instanceof Literal)) {
+                    // Last variable is unnecessary when the original expression isn't a Literal.
+                    expressionsToDefer.remove(lastDeferVariable);
+                }
+                finalExpressionBuilder.append(spelExpression.toStringAST());
+            }
+
+            String finalExpression = finalExpressionBuilder.toString();
+
+            for (Map.Entry<String, String> e : expressionsToDefer.entrySet()) {
+                finalExpression = finalExpression.replaceAll(Pattern.quote(e.getValue()), "#" + e.getKey());
+
+                if (!finalExpression.equals(expression.getExpressionString())) {
+                    this.variables.add(e.getKey());
+                }
+            }
+
+            if (!finalExpression.equals(expression.getExpressionString())) {
+                if (expression instanceof SpelExpression spelExpression) {
+                    if (spelExpression.getAST().getChild(0) instanceof Literal) {
+                        // Ex: 'Hello'.contains(#deferred.get('val')
+                        finalExpression = "{(" + finalExpression + ")}";
+                    } else {
+                        finalExpression = "{" + finalExpression + "}";
+                    }
+                }
+
+                this.rebuiltExpressionForDefer = parser.parseExpression(finalExpression);
+            }
+        }
+    }
+
+    private void addDeferExpression(List<SpelNodeImpl> nodes, List<String> deferExpressionsCollector) {
+        final String deferExpression = buildCompoundExpression(nodes).toStringAST();
+
+        if (knownDeferredFunctionHolders.stream().anyMatch(deferExpression::contains)) {
+            deferExpressionsCollector.add(deferExpression);
+        }
+    }
+
+    private boolean makesUseOfDeferFunctions() {
+        return (
+            variables != null &&
+            knownDeferredFunctionHolders != null &&
+            variables.stream().anyMatch(s -> knownDeferredFunctionHolders.contains(s))
+        );
+    }
+
+    private CompoundExpression buildCompoundExpression(List<SpelNodeImpl> sub) {
+        return new CompoundExpression(
+            sub.get(0).getStartPosition(),
+            sub.get(sub.size() - 1).getEndPosition(),
+            sub.toArray(new SpelNodeImpl[0])
+        );
     }
 }

--- a/src/main/java/io/gravitee/el/spel/SpelExpressionParser.java
+++ b/src/main/java/io/gravitee/el/spel/SpelExpressionParser.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.el.spel;
 
+import io.gravitee.el.spel.context.SpelTemplateContext;
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.plugin.cache.common.InMemoryCache;
@@ -56,13 +57,13 @@ public class SpelExpressionParser {
         expressions = new InMemoryCache<>("el", cacheConfiguration);
     }
 
-    public CachedExpression parseAndCacheExpression(String expression) {
+    public CachedExpression parseAndCacheExpression(String expression, SpelTemplateContext templateContext) {
         CachedExpression exp = expressions.get(expression);
         if (exp != null) {
             return exp;
         }
 
-        exp = new CachedExpression(parseExpression(expression));
+        exp = new CachedExpression(parseExpression(expression), this, templateContext.knownDeferredVariablesName());
         expressions.put(expression, exp);
 
         return exp;
@@ -77,7 +78,7 @@ public class SpelExpressionParser {
         return PARSER_CONTEXT;
     }
 
-    private org.springframework.expression.spel.standard.SpelExpressionParser getParser() {
+    org.springframework.expression.spel.standard.SpelExpressionParser getParser() {
         if (expressionParser == null) {
             expressionParser =
                 new org.springframework.expression.spel.standard.SpelExpressionParser(

--- a/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
+++ b/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
@@ -20,9 +20,13 @@ import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.gravitee.el.spel.context.SpelTemplateContext;
 import io.reactivex.rxjava3.core.Maybe;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxThread;
 import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.EvaluationException;
 import org.springframework.expression.Expression;
-import org.springframework.expression.spel.SpelEvaluationException;
+import org.springframework.util.StringUtils;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -50,12 +54,19 @@ public class SpelTemplateEngine implements TemplateEngine {
     }
 
     @Override
+    public <T> T evalBlocking(String expression, Class<T> clazz) {
+        final Context currentContext = Vertx.currentContext();
+        if (currentContext != null && currentContext.isEventLoopContext()) {
+            throw new ExpressionEvaluationException("Cannot evaluate expression " + expression + " on a vertx event loop");
+        }
+
+        return eval(expression, clazz).blockingGet();
+    }
+
+    @Override
     public <T> Maybe<T> eval(String expression, Class<T> clazz) {
         try {
-            CachedExpression cachedExpression = spelExpressionParser.parseAndCacheExpression(expression);
-            return templateContext
-                .evaluationContext(cachedExpression)
-                .flatMapMaybe(evaluationContext -> eval(cachedExpression, evaluationContext, clazz));
+            return eval(spelExpressionParser.parseAndCacheExpression(expression, templateContext), templateContext, clazz);
         } catch (Exception e) {
             return Maybe.error(e);
         }
@@ -66,14 +77,40 @@ public class SpelTemplateEngine implements TemplateEngine {
         return templateContext;
     }
 
-    protected <T> Maybe<T> eval(CachedExpression exp, EvaluationContext evaluationContext, Class<T> clazz) {
-        return Maybe.fromCallable(() -> eval(exp.getExpression(), evaluationContext, clazz));
+    @SuppressWarnings("unchecked")
+    protected <T> Maybe<T> eval(CachedExpression cachedExpression, SpelTemplateContext templateContext, Class<T> clazz) {
+        Expression expression;
+
+        cachedExpression
+            .expressionsToDefer()
+            .forEach((key, exp) ->
+                templateContext.setDeferredVariable(
+                    key,
+                    Maybe.defer(() ->
+                        eval(spelExpressionParser.parseAndCacheExpression("{" + exp + "}", templateContext), templateContext, Object.class)
+                    )
+                )
+            );
+
+        expression = cachedExpression.getExpression();
+
+        return templateContext
+            .evaluationContext(cachedExpression)
+            .flatMapMaybe(evaluationContext -> Maybe.fromCallable(() -> eval(expression, evaluationContext, clazz)))
+            .flatMap(result -> {
+                if (result instanceof Maybe maybeValue) {
+                    // If we end here, the deferred value isn't resolved yet.
+                    return maybeValue;
+                }
+
+                return Maybe.just(result);
+            });
     }
 
     protected <T> T eval(Expression expression, EvaluationContext evaluationContext, Class<T> clazz) {
         try {
             return expression.getValue(evaluationContext, clazz);
-        } catch (SpelEvaluationException spelEvaluationException) {
+        } catch (EvaluationException spelEvaluationException) {
             throw new ExpressionEvaluationException(expression.getExpressionString(), spelEvaluationException);
         }
     }

--- a/src/main/java/io/gravitee/el/spel/context/DeferredFunctionHolder.java
+++ b/src/main/java/io/gravitee/el/spel/context/DeferredFunctionHolder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.context;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface DeferredFunctionHolder {}

--- a/src/main/java/io/gravitee/el/spel/context/ReactiveValueConverter.java
+++ b/src/main/java/io/gravitee/el/spel/context/ReactiveValueConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.context;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Set;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter;
+
+/**
+ * Internal converter allowing to let pass any {@link Maybe} or {@link Single} 'as is'.
+ * The template engine is supposed to know how to deal when a {@link Maybe} or {@link Single} result is encountered and evaluate the final result in non-blocking way.
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ReactiveValueConverter implements GenericConverter {
+
+    @Override
+    public Set<ConvertiblePair> getConvertibleTypes() {
+        return Set.of(new ConvertiblePair(Maybe.class, Object.class), new ConvertiblePair(Single.class, Object.class));
+    }
+
+    @Override
+    public Object convert(Object source, @NonNull TypeDescriptor sourceType, @NonNull TypeDescriptor targetType) {
+        // The source is a Maybe or a Single, let the engine evaluate in non-blocking way.
+        return source;
+    }
+}

--- a/src/main/java/io/gravitee/el/spel/context/SecuredEvaluationContext.java
+++ b/src/main/java/io/gravitee/el/spel/context/SecuredEvaluationContext.java
@@ -16,6 +16,7 @@
 package io.gravitee.el.spel.context;
 
 import java.util.*;
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.expression.*;
 import org.springframework.expression.spel.support.*;
 
@@ -25,7 +26,7 @@ import org.springframework.expression.spel.support.*;
  */
 public class SecuredEvaluationContext implements EvaluationContext {
 
-    // No constructor resolver to avoid object instantiation.
+    // Secured constructor resolver to only allow whitelisted constructors.
     private static final List<ConstructorResolver> constructorResolvers = Collections.singletonList(new SecuredContructorResolver());
 
     // Read only property access.
@@ -38,9 +39,15 @@ public class SecuredEvaluationContext implements EvaluationContext {
     // Secure method resolver to allow only whitelisted methods.
     private static final List<MethodResolver> methodResolvers = Collections.singletonList(new SecuredMethodResolver());
 
+    private static final DefaultConversionService conversionService = new DefaultConversionService();
+
+    static {
+        conversionService.addConverter(new ReactiveValueConverter());
+    }
+
     // Standards.
     private static final TypeLocator typeLocator = new StandardTypeLocator();
-    private static final TypeConverter typeConverter = new StandardTypeConverter();
+    private static final TypeConverter typeConverter = new StandardTypeConverter(conversionService);
     private static final TypeComparator typeComparator = new StandardTypeComparator();
     private static final OperatorOverloader operatorOverloader = new StandardOperatorOverloader();
 

--- a/src/test/java/io/gravitee/el/spel/TestDeferredFunctionHolder.java
+++ b/src/test/java/io/gravitee/el/spel/TestDeferredFunctionHolder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel;
+
+import io.gravitee.el.spel.context.DeferredFunctionHolder;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class TestDeferredFunctionHolder implements DeferredFunctionHolder {
+
+    private final Integer delay;
+
+    public TestDeferredFunctionHolder() {
+        this.delay = null;
+    }
+
+    public TestDeferredFunctionHolder(int delay) {
+        this.delay = delay;
+    }
+
+    public Maybe<Integer> getIndex(int index) {
+        return Maybe.just(index);
+    }
+
+    public Maybe<String> get(String val1, String val2) {
+        Maybe<String> maybe = Maybe.just("resolved('" + val1 + "', '" + val2 + "')");
+
+        if (delay != null) {
+            return maybe.delay(delay, TimeUnit.MILLISECONDS);
+        }
+
+        return maybe;
+    }
+
+    public Maybe<List<String>> getList(String val1, String val2) {
+        Maybe<List<String>> maybe = Maybe.just(List.of("resolved('" + val1 + "')", "resolged('" + val2 + "')"));
+
+        if (delay != null) {
+            return maybe.delay(delay, TimeUnit.MILLISECONDS);
+        }
+
+        return maybe;
+    }
+}

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
@@ -28,14 +28,19 @@ import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.gravitee.el.spel.EvaluableRequest;
 import io.gravitee.el.spel.Request;
+import io.gravitee.el.spel.TestDeferredFunctionHolder;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.Vertx;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -68,7 +73,10 @@ class SpelTemplateEngineTest {
 
     @BeforeEach
     void init() {
-        reinitSecuredResolver(null);
+        ConfigurableEnvironment environment = new MockEnvironment()
+            .withProperty(EL_WHITELIST_MODE_KEY, "append")
+            .withProperty(EL_WHITELIST_LIST_KEY + "[0]", "class io.gravitee.el.spel.TestDeferredFunctionHolder");
+        reinitSecuredResolver(environment);
     }
 
     @ParameterizedTest
@@ -311,6 +319,241 @@ class SpelTemplateEngineTest {
         content = "{#jsonPath(#request.content, '$.something')}";
         obs = engine.eval(content, String.class).test();
         obs.assertResult();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_avoid_calling_eval_blocking_on_eventloop() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("name", "gravitee");
+
+        String content = "Hello {#name}";
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Vertx
+            .vertx()
+            .runOnContext(v -> {
+                assertThrows(ExpressionEvaluationException.class, () -> engine.evalBlocking(content, String.class));
+                latch.countDown();
+            });
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isEqualTo(true);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_call_eval_blocking_when_not_on_eventloop() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("name", "gravitee");
+
+        String content = "Hello {#name}";
+
+        assertThat(engine.evalBlocking(content, String.class)).isEqualTo("Hello gravitee");
+    }
+
+    @Test
+    void should_call_literal() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("name", "gravitee");
+
+        String content = "Hello {#name}";
+
+        engine.eval(content, String.class).test().assertResult("Hello gravitee");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{#custom.get('val1', 'val2')}";
+
+        engine.eval(content, String.class).test().assertResult("resolved('val1', 'val2')");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_several_times() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{#custom.get('val1', 'val2')}";
+
+        for (int i = 0; i < 10; i++) {
+            engine.eval(content, String.class).test().assertResult("resolved('val1', 'val2')");
+        }
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_with_delay() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder(200));
+
+        String content = "{#custom.get('val1', 'val2')}";
+
+        engine.eval(content, String.class).test().awaitDone(1, TimeUnit.SECONDS).assertResult("resolved('val1', 'val2')");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_with_list_index() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{#custom.getList('val1', 'val2')[0]}";
+
+        engine.eval(content, String.class).test().assertResult("resolved('val1')");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_with_list_and_el_as_index() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+        engine.getTemplateContext().setVariable("index", 0);
+
+        String content = "{#custom.getList('val1', 'val2')[#index]}";
+
+        engine.eval(content, String.class).test().assertResult("resolved('val1')");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_with_list_and_deferred_as_index() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{#custom.getList('val1', 'val2')[#custom.getIndex(0)]}";
+
+        engine.eval(content, String.class).test().assertResult("resolved('val1')");
+    }
+
+    @Test
+    void should_evaluate_list_with_deferred_as_index() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        engine.getTemplateContext().setVariable("something", "resolved");
+
+        String content = "{#something.split(',')[#custom.getIndex(0)]}";
+
+        engine.eval(content, String.class).test().assertResult("resolved");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_with_el() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+        engine.getTemplateContext().setVariable("properties", Map.of("prop1", "val1", "prop2", "val2"));
+
+        String content = "{#custom.get(#properties['prop1'], #properties['prop2'])}";
+
+        engine.eval(content, String.class).test().assertResult("resolved('val1', 'val2')");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_in_a_literal() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "Hello {#custom.get('val1', 'val2')}";
+
+        engine.eval(content, String.class).test().assertResult("Hello resolved('val1', 'val2')");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_in_a_literal_with_multi_el() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{#custom.get('val1','val2')} is not equals to {#custom.get('val3', 'val4')}";
+
+        engine.eval(content, String.class).test().assertResult("resolved('val1', 'val2') is not equals to resolved('val3', 'val4')");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_and_contains() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{#custom.get('val1', 'v2').contains('resolved')}";
+
+        engine.eval(content, Boolean.class).test().assertResult(true);
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_with_contains_and_deferred_functions_argument() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{#custom.get('val1', 'val2').contains(#custom.get('val3', 'val4'))}";
+
+        engine.eval(content, Boolean.class).test().assertResult(false);
+    }
+
+    @Test
+    void should_evaluate_string_contains() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{('Hello'.contains('Hello'))}";
+
+        engine.eval(content, Boolean.class).test().assertResult(true);
+    }
+
+    @Test
+    void should_evaluate_string_contains_with_deferred_functions() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{('Hello'.contains(#custom.get('val1', 'val2')))}";
+
+        engine.eval(content, String.class).test().assertResult("false");
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_with_complex_el() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+        engine
+            .getTemplateContext()
+            .setVariable(
+                "properties",
+                Map.of(
+                    "prop1",
+                    "val1",
+                    "prop2",
+                    "val2",
+                    "prop3",
+                    "val3",
+                    "prop4",
+                    "val4",
+                    "prop5",
+                    "val5",
+                    "prop6",
+                    "val6",
+                    "prop7",
+                    "val7",
+                    "prop8",
+                    "val8"
+                )
+            );
+
+        String content =
+            "{#custom.get(#custom.get(#properties['prop1'], #properties['prop2']), #custom.get(#properties['prop3'], #properties['prop4'])).concat(' ').concat(#custom.get(#custom.get(#properties['prop5'], #properties['prop6']), #custom.get(#properties['prop7'], #properties['prop8'])))}";
+
+        engine
+            .eval(content, String.class)
+            .test()
+            .assertResult(
+                "resolved('resolved('val1', 'val2')', 'resolved('val3', 'val4')') resolved('resolved('val5', 'val6')', 'resolved('val7', 'val8')')"
+            );
+    }
+
+    @Test
+    void should_evaluate_deferred_functions_with_type() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setDeferredFunctionHolderVariable("custom", new TestDeferredFunctionHolder());
+
+        String content = "{ T(java.util.Base64).getEncoder().encodeToString(#custom.get('val1', 'val2').getBytes()) }";
+
+        engine.eval(content, String.class).test().assertResult("cmVzb2x2ZWQoJ3ZhbDEnLCAndmFsMicp");
     }
 
     @Test
@@ -631,14 +874,14 @@ class SpelTemplateEngineTest {
     }
 
     @Test
-    void shouldThrowParsingExceptionWithWrongExpression() {
+    void should_throw_parsing_exception_with_wrong_expression() {
         String wrongExpression = "{#";
         final TemplateEngine engine = TemplateEngine.templateEngine();
         engine.eval(wrongExpression, Boolean.class).test().assertFailure(ParseException.class);
     }
 
     @Test
-    void shouldGetFirstHeader() {
+    void should_get_first_header() {
         final List<CharSequence> values = new ArrayList<>();
         values.add("my_api_host");
         values.add("value2");
@@ -654,7 +897,7 @@ class SpelTemplateEngineTest {
     }
 
     @Test
-    void shouldConvertToSingleValueMap() {
+    void should_convert_to_single_value_map() {
         final List<CharSequence> values = new ArrayList<>();
         values.add("my_api_host");
         values.add("value2");
@@ -675,7 +918,7 @@ class SpelTemplateEngineTest {
     }
 
     @Test
-    void shouldHeadersContainsAllKeys() {
+    void should_headers_contains_all_keys() {
         final HttpHeaders headers = HttpHeaders.create().add("Header1", "value1").add("Header2", "value2");
         when(request.headers()).thenReturn(headers);
 
@@ -687,7 +930,7 @@ class SpelTemplateEngineTest {
     }
 
     @Test
-    void shouldGetValueAsBoolean() {
+    void should_get_value_as_boolean() {
         final HttpHeaders headers = HttpHeaders.create().add("X-Gravitee-Endpoint", "true");
 
         when(request.headers()).thenReturn(headers);
@@ -714,7 +957,7 @@ class SpelTemplateEngineTest {
     }
 
     @Test
-    void shouldEvaluateSimpleRegex() {
+    void should_evaluate_simple_regex() {
         String pathInfo = "/user";
         String regex = "^\\/user";
 
@@ -730,7 +973,7 @@ class SpelTemplateEngineTest {
     }
 
     @Test
-    void shouldEvaluateRegexWithQuantifiers() {
+    void should_evaluate_regex_with_quantifiers() {
         String pathInfo = "/user/01234567-abcd-abcd-abcd-012345678912/file";
         String regex = "^\\/user\\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(\\/file)?$";
 
@@ -758,7 +1001,7 @@ class SpelTemplateEngineTest {
             "{ \"status\": \"'{2}'\"  }",
         }
     )
-    void shouldEvaluateSimpleStringWithoutExpressions(String expression) {
+    void should_evaluate_simple_string_without_expressions(String expression) {
         final String evaluatedExpression = TemplateEngine.templateEngine().evalNow(expression, String.class);
         assertEquals(expression, evaluatedExpression);
     }
@@ -780,7 +1023,7 @@ class SpelTemplateEngineTest {
 
     @ParameterizedTest
     @MethodSource("expressionsWithoutVariables")
-    void shouldEvaluateStringWithExpression(String expression, String expectedResult) {
+    void should_evaluate_string_with_expression(String expression, String expectedResult) {
         final String evaluatedExpression = TemplateEngine.templateEngine().evalNow(expression, String.class);
         assertEquals(expectedResult, evaluatedExpression);
     }
@@ -802,7 +1045,7 @@ class SpelTemplateEngineTest {
 
     @ParameterizedTest
     @MethodSource("expressionsWithVariables")
-    void shouldEvaluateStringWithExpressionContainingVariables(String expression, String expectedResult) {
+    void should_evaluate_string_with_expression_containing_variables(String expression, String expectedResult) {
         lenient().when(request.pathInfo()).thenReturn("/my/path/A58");
         final TemplateEngine engine = TemplateEngine.templateEngine();
         engine.getTemplateContext().setVariable("request", new EvaluableRequest(request));


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-476

**Description**

This PR brings support for calling functions that returns a reactive Maybe or Single. This opens the door to implementing fetch secrets dynamically using EL expressions such as

```
org.apache.kafka.common.security.plain.PlainLoginModule required \
 username="admin" \
 password="{#secrets.get(#context.principal.claims['role'])} ";
```



