### PR TITLE
feat: allow to duplicate a template engine

### DIFF
--- a/src/main/java/io/gravitee/el/TemplateEngine.java
+++ b/src/main/java/io/gravitee/el/TemplateEngine.java
@@ -38,6 +38,16 @@ public interface TemplateEngine {
     }
 
     /**
+     * Creates a {@link TemplateEngine} instance from an existing one. The goal is to share the same variables.
+     *
+     * @param templateEngine the template engine to copy variables from
+     * @return a {@link TemplateEngine} instance for single use.
+     */
+    static TemplateEngine fromTemplateEngine(TemplateEngine templateEngine) {
+        return factory.fromTemplateEngine(templateEngine);
+    }
+
+    /**
      * @deprecated this method is deprecated in favor of {@link #eval(String, Class)} that supports reactive.
      * Evaluate the el expression against the current template context.
      *

--- a/src/main/java/io/gravitee/el/TemplateEngineFactory.java
+++ b/src/main/java/io/gravitee/el/TemplateEngineFactory.java
@@ -20,4 +20,6 @@ package io.gravitee.el;
  */
 public interface TemplateEngineFactory {
     TemplateEngine templateEngine();
+
+    TemplateEngine fromTemplateEngine(TemplateEngine templateEngine);
 }

--- a/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
+++ b/src/main/java/io/gravitee/el/spel/SpelTemplateEngine.java
@@ -42,6 +42,14 @@ public class SpelTemplateEngine implements TemplateEngine {
         this.templateContext = new SpelTemplateContext();
     }
 
+    public SpelTemplateEngine(TemplateEngine templateEngine) {
+        if (!(templateEngine instanceof SpelTemplateEngine other)) {
+            throw new IllegalArgumentException("TemplateEngine must be an instance of SpelTemplateEngine to be duplicated.");
+        }
+        this.spelExpressionParser = other.spelExpressionParser;
+        this.templateContext = new SpelTemplateContext(other.templateContext);
+    }
+
     @Override
     public <T> T getValue(String expression, Class<T> clazz) {
         return evalNow(expression, clazz);

--- a/src/main/java/io/gravitee/el/spel/SpelTemplateEngineFactory.java
+++ b/src/main/java/io/gravitee/el/spel/SpelTemplateEngineFactory.java
@@ -29,4 +29,9 @@ public class SpelTemplateEngineFactory implements TemplateEngineFactory {
     public TemplateEngine templateEngine() {
         return new SpelTemplateEngine(EXPRESSION_PARSER);
     }
+
+    @Override
+    public TemplateEngine fromTemplateEngine(TemplateEngine templateEngine) {
+        return new SpelTemplateEngine(templateEngine);
+    }
 }

--- a/src/main/java/io/gravitee/el/spel/context/SecuredEvaluationContext.java
+++ b/src/main/java/io/gravitee/el/spel/context/SecuredEvaluationContext.java
@@ -115,4 +115,12 @@ public class SecuredEvaluationContext implements EvaluationContext {
     public Object lookupVariable(String name) {
         return this.variables.get(name);
     }
+
+    void putVariables(Map<String, Object> variables) {
+        this.variables.putAll(variables);
+    }
+
+    Map<String, Object> getVariables() {
+        return this.variables;
+    }
 }

--- a/src/main/java/io/gravitee/el/spel/context/SpelTemplateContext.java
+++ b/src/main/java/io/gravitee/el/spel/context/SpelTemplateContext.java
@@ -49,6 +49,17 @@ public class SpelTemplateContext implements TemplateContext {
         context.setVariable("xmlEscape", XML_ESCAPE_EVAL_METHOD);
     }
 
+    public SpelTemplateContext(SpelTemplateContext templateContext) {
+        this();
+        if (templateContext.deferredVariables != null) {
+            this.deferredVariables = new HashMap<>(templateContext.deferredVariables);
+        }
+        if (templateContext.deferredFunctionsHolders != null) {
+            this.deferredFunctionsHolders = new HashMap<>(templateContext.deferredFunctionsHolders);
+        }
+        ((SecuredEvaluationContext) context).putVariables(new HashMap<>(templateContext.getVariables()));
+    }
+
     @Override
     public void setVariable(String name, Object value) {
         context.setVariable(name, value);
@@ -131,5 +142,17 @@ public class SpelTemplateContext implements TemplateContext {
         }
 
         deferredVariables.put(name, deferred);
+    }
+
+    Map<String, Object> getVariables() {
+        return ((SecuredEvaluationContext) this.context).getVariables();
+    }
+
+    Map<String, Object> getDeferredVariables() {
+        return deferredVariables;
+    }
+
+    Map<String, Object> getDeferredFunctionsHolders() {
+        return deferredFunctionsHolders;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12561

**Description**

Add the possibility to create a template engine from an existing one, by copying its variables
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.0-allow-to-duplicate-template-context-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/4.3.0-allow-to-duplicate-template-context-SNAPSHOT/gravitee-expression-language-4.3.0-allow-to-duplicate-template-context-SNAPSHOT.zip)
  <!-- Version placeholder end -->
