### PR TITLE
feat: add #jsonEscape EL helper for JSON-safe string substitution

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.claude/
+.worktrees/

--- a/src/main/java/io/gravitee/el/spel/context/SpelTemplateContext.java
+++ b/src/main/java/io/gravitee/el/spel/context/SpelTemplateContext.java
@@ -18,6 +18,7 @@ package io.gravitee.el.spel.context;
 import io.gravitee.el.TemplateContext;
 import io.gravitee.el.spel.CachedExpression;
 import io.gravitee.el.spel.function.json.JsonPathFunction;
+import io.gravitee.el.spel.function.json.escape.JsonEscapeFunction;
 import io.gravitee.el.spel.function.xml.XPathFunction;
 import io.gravitee.el.spel.function.xml.escape.XmlEscapeFunction;
 import io.reactivex.rxjava3.core.Completable;
@@ -38,6 +39,7 @@ public class SpelTemplateContext implements TemplateContext {
     protected static final Method JSON_PATH_EVAL_METHOD = BeanUtils.resolveSignature("evaluate", JsonPathFunction.class);
     protected static final Method XPATH_EVAL_METHOD = BeanUtils.resolveSignature("evaluate", XPathFunction.class);
     protected static final Method XML_ESCAPE_EVAL_METHOD = BeanUtils.resolveSignature("evaluate", XmlEscapeFunction.class);
+    protected static final Method JSON_ESCAPE_EVAL_METHOD = BeanUtils.resolveSignature("evaluate", JsonEscapeFunction.class);
     private final EvaluationContext context;
     private Map<String, Object> deferredVariables;
     private Map<String, Object> deferredFunctionsHolders;
@@ -47,6 +49,7 @@ public class SpelTemplateContext implements TemplateContext {
         context.setVariable("jsonPath", JSON_PATH_EVAL_METHOD);
         context.setVariable("xpath", XPATH_EVAL_METHOD);
         context.setVariable("xmlEscape", XML_ESCAPE_EVAL_METHOD);
+        context.setVariable("jsonEscape", JSON_ESCAPE_EVAL_METHOD);
     }
 
     public SpelTemplateContext(SpelTemplateContext templateContext) {

--- a/src/main/java/io/gravitee/el/spel/function/EscapeFunctionUtils.java
+++ b/src/main/java/io/gravitee/el/spel/function/EscapeFunctionUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.function;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class EscapeFunctionUtils {
+
+    private EscapeFunctionUtils() {}
+
+    public static String normalizeToText(Object input) {
+        if (input instanceof String stringInput) {
+            return stringInput;
+        }
+        if (input instanceof Collection<?> collection) {
+            return collection.stream().map(EscapeFunctionUtils::elementToText).collect(Collectors.joining(" "));
+        }
+        if (input.getClass().isArray()) {
+            return IntStream
+                .range(0, Array.getLength(input))
+                .mapToObj(index -> elementToText(Array.get(input, index)))
+                .collect(Collectors.joining(" "));
+        }
+        return input.toString();
+    }
+
+    private static String elementToText(Object element) {
+        return element != null ? element.toString() : "";
+    }
+}

--- a/src/main/java/io/gravitee/el/spel/function/json/escape/JsonEscapeFunction.java
+++ b/src/main/java/io/gravitee/el/spel/function/json/escape/JsonEscapeFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.function.json.escape;
+
+import io.gravitee.el.spel.function.EscapeFunctionUtils;
+import org.apache.commons.text.StringEscapeUtils;
+
+/**
+ * <p>Escaping prevents JSON injection when embedding user input in JSON output.</p>
+ *
+ * @author GraviteeSource Team
+ * @since 4.4.0
+ */
+public final class JsonEscapeFunction {
+
+    private JsonEscapeFunction() {}
+
+    public static String evaluate(Object input) {
+        if (input == null) {
+            return null;
+        }
+        return StringEscapeUtils.escapeJson(EscapeFunctionUtils.normalizeToText(input));
+    }
+}

--- a/src/main/java/io/gravitee/el/spel/function/xml/escape/XmlEscapeFunction.java
+++ b/src/main/java/io/gravitee/el/spel/function/xml/escape/XmlEscapeFunction.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.el.spel.function.xml.escape;
 
+import io.gravitee.el.spel.function.EscapeFunctionUtils;
 import org.apache.commons.text.StringEscapeUtils;
 
 /**
@@ -58,7 +59,7 @@ public final class XmlEscapeFunction {
      * <p>This method handles different input types:</p>
      * <ul>
      *   <li>{@code String} - used directly (most common case)</li>
-     *   <li>{@code Collection/Array} - takes first element if single element, joins with space if multiple</li>
+     *   <li>{@code Collection/Array} - elements joined with space</li>
      *   <li>{@code Number} - converted to string via {@code toString()}</li>
      *   <li>{@code Boolean} - converted to string via {@code toString()}</li>
      *   <li>{@code null} - returns {@code null}</li>
@@ -83,35 +84,6 @@ public final class XmlEscapeFunction {
         if (input == null) {
             return null;
         }
-
-        String text;
-        if (input instanceof String stringInput) {
-            text = stringInput;
-        } else if (input instanceof java.util.Collection<?> collection) {
-            text =
-                switch (collection.size()) {
-                    case 0 -> "";
-                    case 1 -> {
-                        Object firstElement = collection.iterator().next();
-                        yield firstElement != null ? firstElement.toString() : "";
-                    }
-                    default -> String.join(" ", collection.stream().map(obj -> obj != null ? obj.toString() : "").toArray(String[]::new));
-                };
-        } else if (input.getClass().isArray()) {
-            Object[] array = (Object[]) input;
-            text =
-                switch (array.length) {
-                    case 0 -> "";
-                    case 1 -> array[0] != null ? array[0].toString() : "";
-                    default -> String.join(
-                        " ",
-                        java.util.Arrays.stream(array).map(element -> element != null ? element.toString() : "").toArray(String[]::new)
-                    );
-                };
-        } else {
-            text = input.toString();
-        }
-
-        return StringEscapeUtils.escapeXml10(text);
+        return StringEscapeUtils.escapeXml10(EscapeFunctionUtils.normalizeToText(input));
     }
 }

--- a/src/test/java/io/gravitee/el/spel/context/SecuredResolverTestInitializer.java
+++ b/src/test/java/io/gravitee/el/spel/context/SecuredResolverTestInitializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.context;
+
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public final class SecuredResolverTestInitializer {
+
+    private SecuredResolverTestInitializer() {}
+
+    public static void reinit() {
+        reinit(null);
+    }
+
+    public static void reinit(Environment environment) {
+        ReflectionTestUtils.setField(SecuredResolver.class, "instance", null);
+        SecuredResolver.initialize(environment);
+
+        SecuredResolver instance = SecuredResolver.getInstance();
+        SecuredMethodResolver.securedResolver = instance;
+        ReflectionTestUtils.setField(SecuredContructorResolver.class, "securedResolver", instance);
+    }
+}

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateContextTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateContextTest.java
@@ -53,9 +53,11 @@ class SpelTemplateContextTest {
     }
 
     @Test
-    void shouldHaveDefaultJsonPathAndXPathVariables() {
+    void shouldHaveAllBuiltInFunctionVariables() {
         assertNotNull(cut.lookupVariable("jsonPath"));
         assertNotNull(cut.lookupVariable("xpath"));
+        assertNotNull(cut.lookupVariable("xmlEscape"));
+        assertNotNull(cut.lookupVariable("jsonEscape"));
     }
 
     @Test

--- a/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
+++ b/src/test/java/io/gravitee/el/spel/context/SpelTemplateEngineTest.java
@@ -61,7 +61,6 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.expression.ParseException;
 import org.springframework.mock.env.MockEnvironment;
-import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -735,6 +734,31 @@ class SpelTemplateEngineTest {
     }
 
     @Test
+    void should_allow_registered_el_function_when_built_in_whitelist_not_loaded() {
+        ConfigurableEnvironment environment = new MockEnvironment()
+            .withProperty(EL_WHITELIST_MODE_KEY, "replace")
+            .withProperty(EL_WHITELIST_LIST_KEY + "[0]", "method java.lang.System getenv");
+
+        reinitSecuredResolver(environment);
+
+        final TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("input", "hello \"world\"");
+
+        assertThat(engine.evalNow("{#jsonEscape(#input)}", String.class)).isEqualTo("hello \\\"world\\\"");
+        assertThat(engine.evalNow("{#xmlEscape(#input)}", String.class)).isEqualTo("hello &quot;world&quot;");
+    }
+
+    @Test
+    void should_not_allow_direct_type_call_to_escape_function() {
+        final TemplateEngine engine = TemplateEngine.templateEngine();
+
+        final TestObserver<Object> obs = engine
+            .eval("{T(io.gravitee.el.spel.function.json.escape.JsonEscapeFunction).evaluate('test')}", Object.class)
+            .test();
+        obs.assertError(ExpressionEvaluationException.class);
+    }
+
+    @Test
     void should_ignore_unknown_whitelisted_classes_or_methods() {
         ConfigurableEnvironment environment = new MockEnvironment()
             .withProperty(EL_WHITELIST_MODE_KEY, "append")
@@ -879,11 +903,7 @@ class SpelTemplateEngineTest {
     }
 
     private void reinitSecuredResolver(Environment environment) {
-        ReflectionTestUtils.setField(SecuredResolver.class, "instance", null);
-        SecuredResolver.initialize(environment);
-
-        ReflectionTestUtils.setField(SecuredMethodResolver.class, "securedResolver", SecuredResolver.getInstance());
-        ReflectionTestUtils.setField(SecuredContructorResolver.class, "securedResolver", SecuredResolver.getInstance());
+        SecuredResolverTestInitializer.reinit(environment);
     }
 
     @Test
@@ -1122,5 +1142,134 @@ class SpelTemplateEngineTest {
             .contains(Map.entry("test", "hello"), Map.entry("defferedFunction", deferredFunctionHolder));
         assertThat(clonedTemplateContext.getDeferredVariables()).contains(Map.entry("defferedVariable", defferedValue));
         assertThat(clonedTemplateContext.getDeferredFunctionsHolders()).contains(Map.entry("defferedFunction", deferredFunctionHolder));
+    }
+
+    @Test
+    void should_evaluate_built_in_escape_functions_on_a_cloned_engine() {
+        final TemplateEngine originalEngine = TemplateEngine.templateEngine();
+
+        final TemplateEngine clonedEngine = TemplateEngine.fromTemplateEngine(originalEngine);
+
+        clonedEngine.eval("{#jsonEscape('\"')}", String.class).test().assertResult("\\\"");
+        clonedEngine.eval("{#xmlEscape('<')}", String.class).test().assertResult("&lt;");
+    }
+
+    @Test
+    void should_evaluate_a_variable_copied_from_the_original_on_a_cloned_engine() {
+        final TemplateEngine originalEngine = TemplateEngine.templateEngine();
+        originalEngine.getTemplateContext().setVariable("payload", "val\"ue");
+
+        final TemplateEngine clonedEngine = TemplateEngine.fromTemplateEngine(originalEngine);
+
+        clonedEngine.eval("{#jsonEscape(#payload)}", String.class).test().assertResult("val\\\"ue");
+    }
+
+    @Test
+    void should_not_affect_the_original_when_mutating_a_variable_on_the_clone() {
+        final TemplateEngine originalEngine = TemplateEngine.templateEngine();
+        originalEngine.getTemplateContext().setVariable("payload", "val\"ue");
+        final TemplateEngine clonedEngine = TemplateEngine.fromTemplateEngine(originalEngine);
+
+        clonedEngine.getTemplateContext().setVariable("payload", "changed");
+
+        assertThat(originalEngine.getTemplateContext().lookupVariable("payload")).isEqualTo("val\"ue");
+    }
+
+    @Test
+    void should_json_escape_a_context_variable() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("userInput", "say \"hello\"");
+
+        final TestObserver<String> obs = engine.eval("{#jsonEscape(#userInput)}", String.class).test();
+        obs.assertResult("say \\\"hello\\\"");
+    }
+
+    @Test
+    void should_emit_nothing_when_json_escaping_a_null_context_variable() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("userInput", null);
+
+        final TestObserver<String> obs = engine.eval("{#jsonEscape(#userInput)}", String.class).test();
+        obs.assertComplete();
+        assertThat(obs.values()).isEmpty();
+    }
+
+    @Test
+    void should_xml_escape_a_context_variable() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("xml", "<b>a & b</b>");
+
+        final TestObserver<String> obs = engine.eval("{#xmlEscape(#xml)}", String.class).test();
+        obs.assertResult("&lt;b&gt;a &amp; b&lt;/b&gt;");
+    }
+
+    @Test
+    void should_emit_nothing_when_xml_escaping_a_null_context_variable() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("xml", null);
+
+        final TestObserver<String> obs = engine.eval("{#xmlEscape(#xml)}", String.class).test();
+        obs.assertComplete();
+        assertThat(obs.values()).isEmpty();
+    }
+
+    @Test
+    void should_json_escape_the_result_of_xml_escape_when_nested() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+
+        final TestObserver<String> obs = engine.eval("{#jsonEscape(#xmlEscape('<b>\"hi\"</b>'))}", String.class).test();
+        obs.assertResult("&lt;b&gt;&quot;hi&quot;&lt;\\/b&gt;");
+    }
+
+    @Test
+    void should_xml_escape_the_result_of_json_escape_when_nested() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+
+        final TestObserver<String> obs = engine.eval("{#xmlEscape(#jsonEscape('\"hello\"'))}", String.class).test();
+        obs.assertResult("\\&quot;hello\\&quot;");
+    }
+
+    @Test
+    void should_json_escape_twice_when_double_nested() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+
+        final TestObserver<String> obs = engine.eval("{#jsonEscape(#jsonEscape('\"'))}", String.class).test();
+        obs.assertResult("\\\\\\\"");
+    }
+
+    @Test
+    void should_json_escape_a_literal_via_eval_now() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+
+        assertThat(engine.evalNow("{#jsonEscape('say \"hi\"')}", String.class)).isEqualTo("say \\\"hi\\\"");
+    }
+
+    @Test
+    void should_xml_escape_a_literal_via_eval_now() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+
+        assertThat(engine.evalNow("{#xmlEscape('<tag>')}", String.class)).isEqualTo("&lt;tag&gt;");
+    }
+
+    @Test
+    void should_return_null_when_json_escaping_null_via_eval_now() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+
+        assertThat(engine.evalNow("{#jsonEscape(null)}", String.class)).isNull();
+    }
+
+    @Test
+    void should_return_null_when_xml_escaping_null_via_eval_now() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+
+        assertThat(engine.evalNow("{#xmlEscape(null)}", String.class)).isNull();
+    }
+
+    @Test
+    void should_json_escape_a_context_variable_via_eval_now() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("msg", "say \"hi\"");
+
+        assertThat(engine.evalNow("{#jsonEscape(#msg)}", String.class)).isEqualTo("say \\\"hi\\\"");
     }
 }

--- a/src/test/java/io/gravitee/el/spel/function/EscapeFunctionDivergenceTest.java
+++ b/src/test/java/io/gravitee/el/spel/function/EscapeFunctionDivergenceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.el.spel.function.json.escape.JsonEscapeFunction;
+import io.gravitee.el.spel.function.xml.escape.XmlEscapeFunction;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EscapeFunctionDivergenceTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "hello", "abc123" })
+    void should_produce_identical_output_for_plain_ascii(String input) {
+        assertThat(JsonEscapeFunction.evaluate(input)).isEqualTo(XmlEscapeFunction.evaluate(input));
+    }
+
+    @Test
+    void should_diverge_on_double_quote() {
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(JsonEscapeFunction.evaluate("\"")).isEqualTo("\\\"");
+            softly.assertThat(XmlEscapeFunction.evaluate("\"")).isEqualTo("&quot;");
+        });
+    }
+
+    @Test
+    void should_diverge_on_less_than() {
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(JsonEscapeFunction.evaluate("<")).isEqualTo("<");
+            softly.assertThat(XmlEscapeFunction.evaluate("<")).isEqualTo("&lt;");
+        });
+    }
+
+    @Test
+    void should_diverge_on_greater_than() {
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(JsonEscapeFunction.evaluate(">")).isEqualTo(">");
+            softly.assertThat(XmlEscapeFunction.evaluate(">")).isEqualTo("&gt;");
+        });
+    }
+
+    @Test
+    void should_diverge_on_ampersand() {
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(JsonEscapeFunction.evaluate("&")).isEqualTo("&");
+            softly.assertThat(XmlEscapeFunction.evaluate("&")).isEqualTo("&amp;");
+        });
+    }
+
+    @Test
+    void should_diverge_on_backslash() {
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(JsonEscapeFunction.evaluate("\\")).isEqualTo("\\\\");
+            softly.assertThat(XmlEscapeFunction.evaluate("\\")).isEqualTo("\\");
+        });
+    }
+
+    @Test
+    void should_diverge_on_newline() {
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(JsonEscapeFunction.evaluate("\n")).isEqualTo("\\n");
+            softly.assertThat(XmlEscapeFunction.evaluate("\n")).isEqualTo("\n");
+        });
+    }
+
+    @Test
+    void should_both_return_null_for_null_input() {
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(JsonEscapeFunction.evaluate(null)).isNull();
+            softly.assertThat(XmlEscapeFunction.evaluate(null)).isNull();
+        });
+    }
+
+    @Test
+    void should_both_return_empty_string_for_empty_input() {
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(JsonEscapeFunction.evaluate("")).isEmpty();
+            softly.assertThat(XmlEscapeFunction.evaluate("")).isEmpty();
+        });
+    }
+}

--- a/src/test/java/io/gravitee/el/spel/function/EscapeFunctionUtilsTest.java
+++ b/src/test/java/io/gravitee/el/spel/function/EscapeFunctionUtilsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class EscapeFunctionUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("stringInputCases")
+    void should_pass_string_input_through_unchanged(String input) {
+        assertThat(EscapeFunctionUtils.normalizeToText(input)).isEqualTo(input);
+    }
+
+    static Stream<Arguments> stringInputCases() {
+        return Stream.of(Arguments.of("hello world"), Arguments.of(""), Arguments.of("   "));
+    }
+
+    @ParameterizedTest
+    @MethodSource("collectionInputCases")
+    void should_join_collection_elements_with_spaces(List<?> input, String expected) {
+        assertThat(EscapeFunctionUtils.normalizeToText(input)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> collectionInputCases() {
+        return Stream.of(
+            Arguments.of(List.of("a", "b", "c"), "a b c"),
+            Arguments.of(List.of("x"), "x"),
+            Arguments.of(List.of(), ""),
+            Arguments.of(Arrays.asList("a", null, "b"), "a  b")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("arrayInputCases")
+    void should_join_array_elements_with_spaces(Object input, String expected) {
+        assertThat(EscapeFunctionUtils.normalizeToText(input)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> arrayInputCases() {
+        return Stream.of(
+            Arguments.of((Object) new String[] { "x", "y" }, "x y"),
+            Arguments.of(new int[] { 1, 2, 3 }, "1 2 3"),
+            Arguments.of(new boolean[] { true, false }, "true false"),
+            Arguments.of((Object) new String[] { "a", null }, "a ")
+        );
+    }
+
+    @Test
+    void should_convert_scalar_input_via_to_string() {
+        assertThat(EscapeFunctionUtils.normalizeToText(42)).isEqualTo("42");
+    }
+
+    @Test
+    void should_throw_npe_for_null_input() {
+        assertThatThrownBy(() -> EscapeFunctionUtils.normalizeToText(null)).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/io/gravitee/el/spel/function/json/escape/JsonEscapeFunctionTest.java
+++ b/src/test/java/io/gravitee/el/spel/function/json/escape/JsonEscapeFunctionTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.el.spel.function.json.escape;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.el.exceptions.ExpressionEvaluationException;
+import io.gravitee.el.spel.context.SecuredResolverTestInitializer;
+import io.reactivex.rxjava3.observers.TestObserver;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JsonEscapeFunctionTest {
+
+    @BeforeEach
+    void setUp() {
+        SecuredResolverTestInitializer.reinit();
+    }
+
+    @ParameterizedTest
+    @MethodSource("elStringInputCases")
+    void should_handle_string_inputs_in_el(String expression, String expected) {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval(expression, String.class).test().assertResult(expected);
+    }
+
+    static Stream<Arguments> elStringInputCases() {
+        return Stream.of(
+            Arguments.of("{#jsonEscape('say \"hi\"')}", "say \\\"hi\\\""),
+            Arguments.of("{#jsonEscape(\"\")}", ""),
+            Arguments.of("{#jsonEscape('   ')}", "   "),
+            Arguments.of("{#jsonEscape('/api/v1')}", "\\/api\\/v1")
+        );
+    }
+
+    @Test
+    void should_handle_null_input_in_el() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        TestObserver<String> obs = engine.eval("{#jsonEscape(null)}", String.class).test();
+        obs.assertComplete();
+        assertThat(obs.values()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "123, 123", "true, true" })
+    void should_handle_scalar_non_string_types(String value, String expected) {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval("{#jsonEscape(" + value + ")}", String.class).test().assertResult(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("collectionInputCases")
+    void should_handle_collection_inputs(String elExpression, String expected) {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval(elExpression, String.class).test().assertResult(expected);
+    }
+
+    static Stream<Arguments> collectionInputCases() {
+        return Stream.of(
+            Arguments.of("{#jsonEscape({})}", ""),
+            Arguments.of("{#jsonEscape({'hello'})}", "hello"),
+            Arguments.of("{#jsonEscape({'hello', 'world'})}", "hello world")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("escapeCharacterCases")
+    void should_escape_special_characters(String input, String expected) {
+        assertThat(JsonEscapeFunction.evaluate(input)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> escapeCharacterCases() {
+        return Stream.of(
+            Arguments.of("hello \"world\"", "hello \\\"world\\\""),
+            Arguments.of("a\\b", "a\\\\b"),
+            Arguments.of("a\nb", "a\\nb"),
+            Arguments.of("a\tb", "a\\tb"),
+            Arguments.of("a\rb", "a\\rb"),
+            Arguments.of("a\bb", "a\\bb"),
+            Arguments.of("a\fb", "a\\fb"),
+            Arguments.of("/", "\\/"),
+            Arguments.of("   ", "   "),
+            Arguments.of("hello\u0001world", "hello\\u0001world")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonAsciiInputCases")
+    void should_escape_non_ascii_characters(String input, String expected) {
+        assertThat(JsonEscapeFunction.evaluate(input)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> nonAsciiInputCases() {
+        return Stream.of(Arguments.of("café", "caf\\u00E9"), Arguments.of("世界", "\\u4E16\\u754C"), Arguments.of("🚀", "\\uD83D\\uDE80"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("templateVariableCases")
+    void should_escape_control_characters_from_template_variable(String value, String expected) {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.getTemplateContext().setVariable("payload", value);
+        engine.eval("{#jsonEscape(#payload)}", String.class).test().assertResult(expected);
+    }
+
+    static Stream<Arguments> templateVariableCases() {
+        return Stream.of(Arguments.of("line1\nline2", "line1\\nline2"), Arguments.of("col1\tcol2", "col1\\tcol2"));
+    }
+
+    @Test
+    void should_return_null_for_null_input() {
+        assertThat(JsonEscapeFunction.evaluate(null)).isNull();
+    }
+
+    @ParameterizedTest
+    @MethodSource("arrayInputCases")
+    void should_handle_array_inputs(Object input, String expected) {
+        assertThat(JsonEscapeFunction.evaluate(input)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> arrayInputCases() {
+        return Stream.of(
+            Arguments.of(new int[] { 1, 2, 3 }, "1 2 3"),
+            Arguments.of((Object) new Object[] { "hello" }, "hello"),
+            Arguments.of((Object) new String[] { "hello", "world" }, "hello world")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullSubstitutionCases")
+    void should_substitute_empty_string_for_null(Object input, String expected) {
+        assertThat(JsonEscapeFunction.evaluate(input)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> nullSubstitutionCases() {
+        return Stream.of(
+            Arguments.of(Arrays.asList((Object) null), ""),
+            Arguments.of(Arrays.asList("a", null, "b"), "a  b"),
+            Arguments.of((Object) new Object[] { null }, ""),
+            Arguments.of((Object) new Object[] { "a", null, "b" }, "a  b")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("sandboxBlockedArguments")
+    void should_reject_non_whitelisted_argument(String expression) {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval(expression, String.class).test().assertError(ExpressionEvaluationException.class);
+    }
+
+    static Stream<Arguments> sandboxBlockedArguments() {
+        return Stream.of(
+            Arguments.of("{#jsonEscape(T(java.lang.Runtime).getRuntime())}"),
+            Arguments.of("{#jsonEscape(new java.lang.Thread())}")
+        );
+    }
+
+    @Test
+    void should_allow_whitelisted_argument() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval("{#jsonEscape(T(java.lang.Math).abs(-42))}", String.class).test().assertResult("42");
+    }
+
+    @ParameterizedTest
+    @MethodSource("wrongArityExpressions")
+    void should_error_on_wrong_arity(String expression) {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval(expression, String.class).test().assertError(Exception.class);
+    }
+
+    static Stream<Arguments> wrongArityExpressions() {
+        return Stream.of(Arguments.of("{#jsonEscape()}"), Arguments.of("{#jsonEscape('a','b')}"));
+    }
+}

--- a/src/test/java/io/gravitee/el/spel/function/xml/escape/XmlEscapeFunctionTest.java
+++ b/src/test/java/io/gravitee/el/spel/function/xml/escape/XmlEscapeFunctionTest.java
@@ -18,31 +18,25 @@ package io.gravitee.el.spel.function.xml.escape;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.el.TemplateEngine;
-import io.gravitee.el.spel.context.SecuredContructorResolver;
-import io.gravitee.el.spel.context.SecuredMethodResolver;
-import io.gravitee.el.spel.context.SecuredResolver;
+import io.gravitee.el.exceptions.ExpressionEvaluationException;
+import io.gravitee.el.spel.context.SecuredResolverTestInitializer;
 import io.reactivex.rxjava3.observers.TestObserver;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class XmlEscapeFunctionTest {
 
     @BeforeEach
     void setUp() {
-        reinitSecuredResolver();
-    }
-
-    private void reinitSecuredResolver() {
-        ReflectionTestUtils.setField(SecuredResolver.class, "instance", null);
-        SecuredResolver.initialize(null);
-
-        SecuredResolver instance = ReflectionTestUtils.invokeMethod(SecuredResolver.class, "getInstance");
-        ReflectionTestUtils.setField(SecuredMethodResolver.class, "securedResolver", instance);
-        ReflectionTestUtils.setField(SecuredContructorResolver.class, "securedResolver", instance);
+        SecuredResolverTestInitializer.reinit();
     }
 
     @Test
@@ -84,13 +78,18 @@ class XmlEscapeFunctionTest {
         assertThat(obs.values()).isEmpty();
     }
 
-    @Test
-    void should_handle_empty_string_in_el() {
+    @ParameterizedTest
+    @ValueSource(strings = { "", "   " })
+    void should_leave_blank_and_empty_strings_unchanged_in_el(String input) {
         TemplateEngine engine = TemplateEngine.templateEngine();
-        TestObserver<String> obs = engine.eval("{#xmlEscape(\"\")}", String.class).test();
+        TestObserver<String> obs = engine.eval("{#xmlEscape('" + input + "')}", String.class).test();
         obs.assertComplete();
-        String result = obs.values().get(0);
-        assertThat(result).isEmpty();
+        assertThat(obs.values().get(0)).isEqualTo(input);
+    }
+
+    @Test
+    void should_return_blank_string_unchanged() {
+        assertThat(XmlEscapeFunction.evaluate("   ")).isEqualTo("   ");
     }
 
     @Test
@@ -209,5 +208,46 @@ class XmlEscapeFunctionTest {
         String result = XmlEscapeFunction.evaluate(injectionPayload);
 
         assertThat(result).isEqualTo("1&lt;/web:id&gt;&lt;web:id&gt;2").doesNotContain("<", ">").contains("&lt;", "&gt;");
+    }
+
+    @ParameterizedTest
+    @MethodSource("primitiveArrays")
+    void should_handle_primitive_array(Object input, String expected) {
+        assertThat(XmlEscapeFunction.evaluate(input)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> primitiveArrays() {
+        return Stream.of(Arguments.of(new int[] { 1, 2 }, "1 2"), Arguments.of(new boolean[] { true, false }, "true false"));
+    }
+
+    @Test
+    void should_handle_primitive_char_array_with_xml_special_chars() {
+        assertThat(XmlEscapeFunction.evaluate(new char[] { '<', '&', '>' })).isEqualTo("&lt; &amp; &gt;");
+    }
+
+    @Test
+    void should_reject_non_whitelisted_argument() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine
+            .eval("{#xmlEscape(T(java.lang.Runtime).getRuntime())}", String.class)
+            .test()
+            .assertError(ExpressionEvaluationException.class);
+    }
+
+    @Test
+    void should_allow_whitelisted_argument() {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval("{#xmlEscape(T(java.lang.Math).abs(-42))}", String.class).test().assertResult("42");
+    }
+
+    @ParameterizedTest
+    @MethodSource("wrongArityExpressions")
+    void should_error_on_wrong_arity(String expression) {
+        TemplateEngine engine = TemplateEngine.templateEngine();
+        engine.eval(expression, String.class).test().assertError(Exception.class);
+    }
+
+    static Stream<Arguments> wrongArityExpressions() {
+        return Stream.of(Arguments.of("{#xmlEscape()}"), Arguments.of("{#xmlEscape('a','b')}"));
     }
 }


### PR DESCRIPTION
## Issue

[APIM-14528](https://gravitee.atlassian.net/browse/APIM-14528)

## Purpose

EL expressions embedded in JSON response templates (e.g. `{#error.message}`) are substituted as raw strings. When the value contains `"`, `\`, or control characters the resulting body is invalid JSON, causing silent corruption for any client that parses it. The gap is specific to the response-template path — the gateway's built-in error formatter already escapes correctly.

## Summary of changes

- **`JsonEscapeFunction`** — new EL function delegating to Apache Commons Text `StringEscapeUtils.escapeJson()`, registered as `#jsonEscape` in `SpelTemplateContext` alongside the existing `#xmlEscape`.
- **`EscapeFunctionUtils`** — shared input-normalization helper extracted from both escape functions, handling `String`, `Collection`, primitive and `Object` arrays, `null`, and arbitrary objects uniformly.
- **`XmlEscapeFunction`** — refactored to delegate normalization to `EscapeFunctionUtils`; behavior unchanged.
- **`.prettierignore`** — excludes `.claude/` tooling state files from `prettier-maven-plugin` validation, which otherwise fails on unformatted JSON files in that directory.

### Behaviour changes

`#jsonEscape(input)` is now available in EL expressions. Template authors can update affected response templates from `{#error.message}` to `{#jsonEscape(#error.message)}` to produce valid JSON when the error message contains special characters.

## Out of scope

No gateway production-code changes are included. Adopting the fix in APIM requires only a version bump of this library once this PR merges.

[APIM-14528]: https://gravitee.atlassian.net/browse/APIM-14528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.4.0-andres-osorio-APIM-14528-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/el/gravitee-expression-language/4.4.0-andres-osorio-APIM-14528-SNAPSHOT/gravitee-expression-language-4.4.0-andres-osorio-APIM-14528-SNAPSHOT.zip)
  <!-- Version placeholder end -->
